### PR TITLE
added arrays support to optimize{}

### DIFF
--- a/src/main/scala/scala/collection/optimizer/package.scala
+++ b/src/main/scala/scala/collection/optimizer/package.scala
@@ -8,7 +8,7 @@ import scala.reflect.macros._
 
 
 package object optimizer {
-  final val debug = falsex
+  final val debug = false
 
   def optimize[T](exp: T) = macro optimize_impl[T]
 

--- a/src/main/scala/scala/collection/optimizer/package.scala
+++ b/src/main/scala/scala/collection/optimizer/package.scala
@@ -7,10 +7,62 @@ import scala.reflect.macros._
 
 
 
+
 package object optimizer {
-  final val debug = false
+  final val debugOutput = false
+  final def debug(s: String) = if (debugOutput) println(s)
+  final val echoSplicedCode = false
 
   def optimize[T](exp: T) = macro optimize_impl[T]
+
+  /** Eliminates consecutive Box&Unbox pairs */
+  def optimize_postprocess[T](exp: T) = macro optimize_postprocess_impl[T]
+
+  def optimize_postprocess_impl[T: c.WeakTypeTag](c: WhiteboxContext)(exp: c.Expr[T]) = {
+    import c.universe._
+    import Flag._
+
+    object BoxUnboxEliminating extends Transformer {
+      override def transform(tree: Tree): Tree = {
+        val res = tree match {
+          case q"$xs.seq.toPar" => q"$xs"
+          case q"$xs.toPar.seq" => q"$xs"
+          case q"scala.this.Predef.intArrayOps($arr).repr" => q"$arr"
+          case q"scala.this.Predef.longArrayOps($arr).repr" => q"$arr"
+          case q"scala.this.Predef.refArrayOps($arr).repr" => q"$arr"
+          case q"scala.this.Predef.shortArrayOps($arr).repr" => q"$arr"
+          case q"scala.this.Predef.unitArrayOps($arr).repr" => q"$arr"
+          case q"scala.this.Predef.booleanArrayOps($arr).repr" => q"$arr"
+          case q"scala.this.Predef.byteArrayOps($arr).repr" => q"$arr"
+          case q"scala.this.Predef.charArrayOps($arr).repr" => q"$arr"
+          case q"scala.this.Predef.doubleArrayOps($arr).repr" => q"$arr"
+          case q"scala.this.Predef.floatArrayOps($arr).repr" => q"$arr"
+          case q"scala.this.Predef.genericArrayOps[$tags]($arr).repr" => q"$arr"
+
+          case q"scala.Predef.intArrayOps($arr).repr" => q"$arr"
+          case q"scala.Predef.longArrayOps($arr).repr" => q"$arr"
+          case q"scala.Predef.refArrayOps($arr).repr" => q"$arr"
+          case q"scala.Predef.shortArrayOps($arr).repr" => q"$arr"
+          case q"scala.Predef.unitArrayOps($arr).repr" => q"$arr"
+          case q"scala.Predef.booleanArrayOps($arr).repr" => q"$arr"
+          case q"scala.Predef.byteArrayOps($arr).repr" => q"$arr"
+          case q"scala.Predef.charArrayOps($arr).repr" => q"$arr"
+          case q"scala.Predef.doubleArrayOps($arr).repr" => q"$arr"
+          case q"scala.Predef.floatArrayOps($arr).repr" => q"$arr"
+          case q"scala.Predef.genericArrayOps[$tags]($arr).repr" => q"$arr"
+
+          case _ => tree
+        }
+
+        super.transform(res)
+      }
+    }
+
+    val t = BoxUnboxEliminating.transform(exp.tree)
+    if (echoSplicedCode) println(t)
+    (c.resetAllAttrs(t))
+  }
+  
 
   def optimize_impl[T: c.WeakTypeTag](c: WhiteboxContext)(exp: c.Expr[T]) = {
     import c.universe._
@@ -20,49 +72,40 @@ package object optimizer {
       q"""
          import scala.collection.par._
          import scala.reflect.ClassTag
+         import scala.math.Ordering
          implicit val dummy$$0 = Scheduler.Implicits.sequential
 
          $tree"""
     }
+    var allTypesFound = true // if we haven't found type somewhere, it means that we've spliced informative changes
+    var progress = false
 
     object CastingTransformer extends Transformer {
       override def transform(tree: Tree): Tree = {
 
+        /** gives seq from Par[Seq], consecutive .toPar.seq if created will be removed during post-processing */
         def unPar(tree: Tree) = {
           import scala.collection.par.Par
-          val treeWithImports = addImports(tree)
-          if(debug) println("typechecking " + treeWithImports)
-          val typeChecked = c.typeCheck(treeWithImports)
           val result = {
-            if (typeChecked.tpe.typeSymbol == typeOf[Par[_]].typeSymbol)  q"$tree.seq"
+            if ((tree.tpe ne null) && (tree.tpe.typeSymbol == typeOf[Par[_]].typeSymbol))  q"$tree.seq"
             else tree
           }
           result 
         }
 
+        /** gives from WrappedArray or ArrayOps an Array */
         def unWrapArray(tree: Tree) = {
-          val treeWithImports = addImports(tree)
-          if (debug) println("unwrapping " + treeWithImports)
-          val typeChecked = c.typeCheck(treeWithImports)
-          if (debug) println("got type " + typeChecked.tpe)
           val resultWrapped = {
-            if (typeChecked.tpe.baseClasses.contains(typeOf[scala.collection.mutable.WrappedArray[_]].typeSymbol)) {
-                if (debug) println("*********************unwrapping to array!")
-                val r = q"$tree.array"
-                r.setType(c.typeCheck(q"$typeChecked.array").tpe)
-                r
-              }
-              else {
-                if (typeChecked.tpe.baseClasses.contains(typeOf[scala.collection.mutable.ArrayOps[_]].typeSymbol)) {
-                  if (debug) println("*********************unwrapping to array!")
-                  val r = q"$tree.repr"
-                  r.setType(c.typeCheck(q"$typeChecked.repr").tpe)
-                  r
-                } else tree
-              }
+            if ((tree.tpe ne null) && tree.tpe.baseClasses.contains(typeOf[collection.mutable.WrappedArray[_]].typeSymbol)) {
+              debug(s"*********************unwrapping to array!\n$tree")
+              q"$tree.array"
+              } else {
+              if ((tree.tpe ne null) && tree.tpe.baseClasses.contains(typeOf[collection.mutable.ArrayOps[_]].typeSymbol)) {
+                debug(s"*********************unwrapping to array!\n$tree")
+                q"$tree.repr"
+              } else tree
+            }
           }
-
-
 
           // check for wrap&unwrap
           val result = resultWrapped match {
@@ -92,15 +135,8 @@ package object optimizer {
             case q"scala.Predef.genericArrayOps[$tags]($arr).repr" => q"$arr"
             case _ => resultWrapped
           }
-
-          if(resultWrapped.tpe ne null) {
-            result.setType(resultWrapped.tpe)
-          }
-
-          if(debug) println(s"wrapped:  ${tree}\nunwrapped: ${result}")
           result 
         }
-
        
         val typesWhiteList = Set(typeOf[List[_]].typeSymbol,
           typeOf[Range].typeSymbol,
@@ -110,67 +146,108 @@ package object optimizer {
           typeOf[scala.collection.mutable.HashMap[_, _]].typeSymbol,
           typeOf[scala.collection.mutable.HashSet[_]].typeSymbol,
           typeOf[scala.collection.mutable.WrappedArray[_]].typeSymbol,
+          typeOf[scala.collection.mutable.ArrayOps[_]].typeSymbol,
           typeOf[Array[_]].typeSymbol
         )
 
         // TODO: fix broken newTermName("groupBy") 
-        val methodWhiteList:Set[Name] = Set(TermName("foreach"), TermName("map"), TermName("reduce"), TermName("exists"), TermName("filter"), TermName("find"), TermName("flatMap"), TermName("forall"), TermName("count"), TermName("fold"), TermName("sum"), TermName("product"), TermName("min"), TermName("max"))
+        val methodWhiteList: Set[Name] = Set(TermName("foreach"), TermName("map"), TermName("reduce"), TermName("exists"), TermName("filter"), TermName("find"), TermName("flatMap"), TermName("forall"), TermName("count"), TermName("fold"), TermName("sum"), TermName("product"), TermName("min"), TermName("max"))
+        // methods that result in Par[collection] and thus require .seq invocation
+        val collectionMethods: Set[Name] = Set(TermName("map"), TermName("filter"), TermName("flatMap"))
+        // methods for which second argument list should be maintained
         val maintain2ArgumentList: Set[Name] = Set(TermName("fold"))
+        // methods that already have an implicit argument list. we reuse it and add scheduler to it
         val append2ArgumentList: Set[Name] = Set(TermName("sum"), TermName("product"), TermName("min"), TermName("max"))
 
         tree match {
           case q"$seqOriginal.aggregate[$tag]($zeroOriginal)($seqopOriginal, $comboopOriginal)" =>
-            val seq = unWrapArray(transform(seqOriginal))
-            val whiteListed = (seq.tpe ne null) && typesWhiteList.contains(seq.tpe.typeSymbol)
-            if (debug) println(s"\n\nAGGREGATEtransforming ${tree}\n seq type is ${seq.tpe}\n type is in whiteList: $whiteListed")
-            val rewrite: Tree = 
+            val seqTransformed = transform(seqOriginal)
+            val whiteListed = (seqTransformed.tpe ne null) && typesWhiteList.contains(seqTransformed.tpe.typeSymbol)
+
+            if (seqTransformed.tpe eq null) {
+              allTypesFound = false
+              debug(s"\n\ntype not found for seqTransformed \nnext op:aggregate")
+            }
+            val rewrite: Tree =
               if (whiteListed) {
+                val seq = unWrapArray(seqTransformed)
+                debug(s"\n\nAGGREGATEtransforming ${tree}\n seq type is ${seq.tpe}\n type is in whiteList: $whiteListed")
                 val seqop = transform(seqopOriginal)
                 val comboop = transform(comboopOriginal)
                 val zero = transform(zeroOriginal)
-                unPar(q"$seq.toPar.aggregate($zero)($seqop)($comboop)")
+                progress = true
+                q"$seq.toPar.aggregate($zero)($seqop)($comboop)"
               } else super.transform(tree)
-            if (whiteListed) if (debug) println("quasiquote formed " + rewrite + "\n")
+            if (whiteListed) debug("quasiquote formed " + rewrite + "\n")
             rewrite
-          case q"$seqOriginal.$method[..$targs]($argsOriginal)($cbf)" => //map
-            val seq = unWrapArray(transform(seqOriginal))
-            val whiteListed = (seq.tpe ne null) && typesWhiteList.contains(seq.tpe.typeSymbol)
+          case q"$seqOriginal.$method[..$targs]($argsOriginal)($cbf)" => //map, fold
+            
+            val seqTansformed = transform(seqOriginal)
+            val whiteListed = (seqTansformed.tpe ne null) && typesWhiteList.contains(seqTansformed.tpe.typeSymbol)
             val methodListed = methodWhiteList.contains(method)
-            if (debug) println(s"\n\nMAPtransforming ${tree}\n seq type is ${seq.tpe}\n type is in whiteList: $whiteListed\nmethod is ${method}\nmethod is in whiteList: $methodListed")
+            if (methodListed && (seqTansformed.tpe eq null)) {
+              allTypesFound = false
+              debug(s"\n\ntype not found for $seqTansformed \nnext op:$method")
+            }
             val rewrite: Tree = 
               if (whiteListed && methodListed) {
+                val seq = unWrapArray(seqTansformed)
+                debug(s"\n\nMAPtransforming ${tree}\n seq type is ${seq.tpe}\n type is in whiteList: $whiteListed\nmethod is ${method}\nmethod is in whiteList: $methodListed")
                 val args = transform(argsOriginal)
+                progress = true
                 if (maintain2ArgumentList.contains(method))
-                  unPar(q"$seq.toPar.$method($args)($cbf)")
-                else unPar(q"$seq.toPar.$method($args)")
-              } else super.transform(tree)
-            if (whiteListed) if (debug) println(s"quasiquote formed ${rewrite}")
+                  q"$seq.toPar.$method($args)($cbf).seq"
+                else q"$seq.toPar.$method($args).seq"
+              }
+              else if (methodListed && ! maintain2ArgumentList.contains(method))  //clean cbf, but not for fold
+                {
+                  val transformedSeq = transform(q"$seqOriginal")
+                  val transformedArgs = transform(q"$argsOriginal")
+                  if ((seqOriginal.toString != transformedSeq.toString) ||(transformedArgs.toString != argsOriginal.toString)) {
+                    debug("**************************************Removed cbf")
+                    debug("seq is $seqOriginal")
+                    debug("transformedSeq is $transformedSeq")
+                    q"$transformedSeq.$method($transformedArgs)"
+                  }
+                  else tree
+                }
+              else super.transform(tree)
+            if (whiteListed && methodListed) debug(s"quasiquote formed ${rewrite}")
             rewrite
           case q"$seqOriginal.$method[..$targs]($argsOriginal)" => //foreach, reduce, groupBy(broken?), exists, filter
-            val seq = unWrapArray(transform(seqOriginal))
-            val whiteListed = (seq.tpe ne null) && typesWhiteList.contains(seq.tpe.typeSymbol)
+            val seqTransformed = transform(seqOriginal)
+            val whiteListed = (seqTransformed.tpe ne null) && typesWhiteList.contains(seqTransformed.tpe.typeSymbol)
             val methodListed = methodWhiteList.contains(method)
-            if (debug) println(s"\n\nFOREACHtransforming ${tree}\n seq type is ${seq.tpe}\n type is in whiteList: $whiteListed\nmethod is ${method}\nmethod is in whiteList: $methodListed")
+            if (methodListed && (seqTransformed.tpe eq null)) {
+              allTypesFound = false
+              debug(s"\n\ntype not found for seqOriginal\n next op:$method")
+            }
             val rewrite: Tree = if (whiteListed && methodListed) {
+              val seq = unWrapArray(seqTransformed)
+              debug(s"\n\nFOREACHtransforming ${tree}\n seq type is ${seq.tpe}\n type is in whiteList: $whiteListed\nmethod is ${method}\nmethod is in whiteList: $methodListed")
               val args = transform(argsOriginal)
-              if (append2ArgumentList.contains(method))
-                  unPar(q"$seq.toPar.$method($args, dummy$$0)")
-              else unPar(q"$seq.toPar.$method($args)") // q"$seq.foreach[..$targs]($args)"
+              progress = true
+              if (append2ArgumentList.contains(method)) //max, sum
+                q"$seq.toPar.$method($args, dummy$$0)"
+              else if (collectionMethods.contains(method)) // filter
+                q"$seq.toPar.$method($args).seq"
+              else q"$seq.toPar.$method($args)" // q"$seq.foreach[..$targs]($args)"
             } else super.transform(tree)
-            if (whiteListed && methodListed) if (debug) println(s"quasiquote formed ${rewrite}")
+            if (whiteListed && methodListed) debug(s"quasiquote formed ${rewrite}")
             rewrite
           case _ =>
-            if (debug) println(s"not transforming $tree") 
+//            debug(s"not transforming $tree") 
             super.transform(tree)
         }
       }
     }
 
-
     val t = CastingTransformer.transform(exp.tree)
-    
-    val resultWithImports = addImports(t)
-     if (debug) println(s"\n\n\nresult: $resultWithImports")
+
+    val resultWithImports =     
+      if (allTypesFound) q"optimize_postprocess{${addImports(t)}}"
+      else addImports(q"optimize{$t}")
+     debug(s"\n\n\n***********************************************************************************\nresult: $resultWithImports")
 
     (c.resetAllAttrs(resultWithImports))
   }

--- a/src/main/scala/scala/collection/optimizer/package.scala
+++ b/src/main/scala/scala/collection/optimizer/package.scala
@@ -8,32 +8,101 @@ import scala.reflect.macros._
 
 
 package object optimizer {
+  final val debug = false
+
   def optimize[T](exp: T) = macro optimize_impl[T]
 
   def optimize_impl[T: c.WeakTypeTag](c: WhiteboxContext)(exp: c.Expr[T]) = {
     import c.universe._
     import Flag._
-    object CastingTransformer extends Transformer {
 
+    def addImports(tree:Tree) = {
+      q"""
+         import scala.collection.par._
+         import scala.reflect.ClassTag
+         implicit val dummy$$0 = Scheduler.Implicits.sequential
+
+         $tree"""
+    }
+
+
+    object CastingTransformer extends Transformer {
       override def transform(tree: Tree): Tree = {
+
         def unPar(tree: Tree) = {
-           println("typechecking " + tree)
-          val typeChecked = c.typeCheck(q"""
-            import scala.collection.par._
-            implicit val dummy$$0 = Scheduler.Implicits.sequential
-            $tree""")
-          val result = if(typeOf[scala.collection.par.Par[_]].typeSymbol == typeChecked.tpe.typeSymbol) q"$tree.seq" else tree
-          result
+          import scala.collection.par.Par
+          val treeWithImports = addImports(tree)
+           if(debug) println("typechecking " + treeWithImports)
+          val typeChecked = c.typeCheck(treeWithImports)
+          if(debug) println("got type " + typeChecked.tpe)
+          if (typeChecked.tpe == typeOf[scala.collection.par.Par[Array[Int]]])
+            if(debug) println("int array")
+          if (typeChecked.tpe == typeOf[scala.collection.par.Par[Array[Double]]])
+            if(debug) println("double array")
+          if (typeChecked.tpe == typeOf[scala.collection.par.Par[scala.collection.immutable.HashSet[Int]]])
+            if(debug) println("int hashset")
+          val result = // we need to temporary wrap arrays to help typecheker
+            if (typeChecked.tpe == typeOf[scala.collection.par.Par[Array[Int]]]) 
+              q"new scala.collection.mutable.WrappedArray.ofInt($tree.seq)"
+            else if (typeChecked.tpe == typeOf[Par[Array[Double]]]) 
+              q"new scala.collection.mutable.WrappedArray.ofDouble($tree.seq)"
+            else if (typeChecked.tpe == typeOf[Par[Array[Long]]])  
+              q"new scala.collection.mutable.WrappedArray.ofLong($tree.seq)"
+            else if (typeChecked.tpe == typeOf[Par[Array[Float]]]) 
+              q"new scala.collection.mutable.WrappedArray.ofFloat($tree.seq)"
+            else if (typeChecked.tpe == typeOf[Par[Array[Char]]]) 
+              q"new scala.collection.mutable.WrappedArray.ofChar($tree.seq)"
+            else if (typeChecked.tpe == typeOf[Par[Array[Byte]]])
+              q"new scala.collection.mutable.WrappedArray.ofByte($tree.seq)"
+            else if (typeChecked.tpe == typeOf[Par[Array[Short]]])
+              q"new scala.collection.mutable.WrappedArray.ofShort($tree.seq)"
+            else if (typeChecked.tpe == typeOf[Par[Array[Boolean]]])
+              q"new scala.collection.mutable.WrappedArray.ofBoolean($tree.seq)"
+            else if (typeChecked.tpe == typeOf[Par[Array[Unit]]])
+              q"new scala.collection.mutable.WrappedArray.ofUnit($tree.seq)"
+            else if (typeChecked.tpe == typeOf[Par[Array[AnyRef]]])
+              q"new scala.collection.mutable.WrappedArray.ofRef($tree.seq)"
+            else if (typeChecked.tpe == typeOf[Par[_]])  q"$tree.seq"
+            else tree
+          
+          result 
         }
+
+        def unWrapArray(tree: Tree) = {
+          val treeWithImports = addImports(tree)
+           if(debug) println("unwrapping " + treeWithImports)
+          val typeChecked = c.typeCheck(treeWithImports)
+          if(debug) println("got type " + typeChecked.tpe)
+          val result = 
+            if (typeChecked.tpe.baseClasses.contains(typeOf[scala.collection.mutable.WrappedArray[_]].typeSymbol)) 
+              {
+                if(debug) println("*********************unwrapping to array!")
+                val r = q"$tree.array"
+                r.setType(c.typeCheck(q"$typeChecked.array").tpe)
+                r
+              }
+              else if (typeChecked.tpe.baseClasses.contains(typeOf[scala.collection.mutable.ArrayOps[_]].typeSymbol)) 
+              {
+                if(debug) println("*********************unwrapping to array!")
+                val r = q"$tree.repr"
+                r.setType(c.typeCheck(q"$typeChecked.repr").tpe)
+                r
+              }
+            else tree
+          
+          result 
+        }
+
        
         val typesWhiteList = Set(typeOf[List[_]].typeSymbol,
           typeOf[Range].typeSymbol,
           typeOf[scala.collection.immutable.Range.Inclusive].typeSymbol,
-          typeOf[scala.collection.immutable.Map[_, _]].typeSymbol,
-          typeOf[scala.collection.immutable.Set[_]].typeSymbol,
+          typeOf[scala.collection.immutable.HashMap[_, _]].typeSymbol,
+          typeOf[scala.collection.immutable.HashSet[_]].typeSymbol,
           typeOf[scala.collection.mutable.HashMap[_, _]].typeSymbol,
-          typeOf[scala.collection.mutable.HashSet[_]].typeSymbol
-//          typeOf[Array[_]].typeSymbol not working, scala.this.Predef.booleanArrayOps & etc
+          typeOf[scala.collection.mutable.HashSet[_]].typeSymbol,
+          typeOf[scala.collection.mutable.WrappedArray[_]].typeSymbol,
+          typeOf[Array[_]].typeSymbol
         )
 
         // TODO: fix broken newTermName("groupBy") 
@@ -42,54 +111,60 @@ package object optimizer {
         val append2ArgumentList: Set[Name] = Set(TermName("sum"), TermName("product"), TermName("min"), TermName("max"))
 
         tree match {
-          case q"$seq.aggregate[$tag]($zero)($seqop, $comboop)" =>
-            // println("AGGREGATEtransforming " + tree)
-            // println("\n\nseq type is " + seq.tpe)
+          case q"$seqO.aggregate[$tag]($zeroO)($seqopO, $comboopO)" =>
+            val seq = unWrapArray(transform(seqO))
+            if(debug) println("\n\nAGGREGATEtransforming " + tree)
+            if(debug) println("seq type is " + seq.tpe)
             val whiteListed = (seq.tpe ne null) && typesWhiteList.contains(seq.tpe.typeSymbol)
-            // println("type is in whiteList: " + whiteListed) 
+            if(debug) println("type is in whiteList: " + whiteListed)
             val rewrite: Tree = 
-              if(whiteListed)
-                  unPar(q"$seq.toPar.aggregate($zero)($seqop)($comboop)")
-               else tree
-            // if (whiteListed) println("quasiquote formed " + rewrite + "\n")
+              if(whiteListed){
+                val seqop = transform(seqopO)
+                val comboop = transform(comboopO)
+                val zero = transform(zeroO)
+                unPar(q"$seq.toPar.aggregate($zero)($seqop)($comboop)")
+              } else super.transform(tree)
+            if (whiteListed) if(debug) println("quasiquote formed " + rewrite + "\n")
+            rewrite
+          case q"$seqO.$method[..$targs]($blaO)($cbf)" => //map
+            val seq = unWrapArray(transform(seqO))
+            if(debug) println("\n\nMAPtransforming " + tree)
+            if(debug) println("recursive seq is " + seq)
+            if(debug) println("seq type is " + seq)
+            if(debug) println("method is " + method)
 
-            super.transform(rewrite)
-
-          case q"$seq.$method[..$targs]($bla)($cbf)" => //map
-            // println("MAPtransforming " + tree)
-            // println("\n\nseq type is " + seq.tpe)
-            // println("method is " + method)
             val whiteListed = (seq.tpe ne null) && typesWhiteList.contains(seq.tpe.typeSymbol)
             val methodListed = methodWhiteList.contains(method)
-            // println("type is in whiteList: " + whiteListed)
-            // println("method is in whiteList: " + methodListed)
+            if(debug) println("type is in whiteList: " + whiteListed)
+            if(debug) println("method is in whiteList: " + methodListed)
             val rewrite: Tree = 
-              if(whiteListed && methodListed)
+              if(whiteListed && methodListed){
+                val bla = transform(blaO)
                 if(maintain2ArgumentList.contains(method))
                   unPar(q"$seq.toPar.$method($bla)($cbf)")
                 else unPar(q"$seq.toPar.$method($bla)")
-               else tree
-            // if (whiteListed) println("quasiquote formed " + rewrite + "\n")
-
-            super.transform(rewrite)
-          case q"$seq.$method[..$targs]($bla)" => //foreach, reduce, groupBy(broken?), exists, filter
-            // println("FOREACHtransforming " + tree)
-            // println("\n\nseq type is " + seq.tpe)
-            // println("method is " + method)
+              } else super.transform(tree)
+            if (whiteListed) if(debug) println("quasiquote formed " + rewrite + "\n")
+            rewrite
+          case q"$seqO.$method[..$targs]($blaO)" => //foreach, reduce, groupBy(broken?), exists, filter
+            val seq = unWrapArray(transform(seqO))
+            if(debug) println("\n\nFOREACHtransforming " + tree)
+            if(debug) println("seq type is " + seq.tpe)
+            if(debug) println("method is " + method)
             val whiteListed = (seq.tpe ne null) && typesWhiteList.contains(seq.tpe.typeSymbol)
             val methodListed = methodWhiteList.contains(method)
-            // println("type is in whiteList: " + whiteListed)
-            // println("method is in whiteList: " + methodListed)
-            val rewrite: Tree = if(whiteListed && methodListed) 
+            if(debug) println("type is in whiteList: " + whiteListed)
+            if(debug) println("method is in whiteList: " + methodListed)
+            val rewrite: Tree = if(whiteListed && methodListed) {
+              val bla = transform(blaO)
               if(append2ArgumentList.contains(method))
                   unPar(q"$seq.toPar.$method($bla, dummy$$0)")
               else unPar(q"$seq.toPar.$method($bla)") // q"$seq.foreach[..$targs]($bla)"
-               else tree
-
-            // if (whiteListed && methodListed) println("quasiquote formed " + rewrite + "\n")
-            super.transform(rewrite)
+            } else super.transform(tree)
+            if (whiteListed && methodListed) if(debug) println("quasiquote formed " + rewrite + "\n")
+            rewrite
           case _ =>
-            // println("not transforming " + tree) 
+            if(debug) println("not transforming " + tree) 
             super.transform(tree)
         }
       }
@@ -97,11 +172,8 @@ package object optimizer {
 
     val t = CastingTransformer.transform(exp.tree)
     
-    val resultWithImports = q"""import scala.collection.par._
-      implicit val dummy$$0 = Scheduler.Implicits.sequential
-      $t
-      """
-    // println("\n\n\nresult: " + resultWithImports)
+    val resultWithImports = addImports(t)
+     if(debug) println("\n\n\nresult: " + resultWithImports)
 
     (c.resetAllAttrs(resultWithImports))
   }

--- a/src/main/scala/scala/collection/par/workstealing/internal/ranges.scala
+++ b/src/main/scala/scala/collection/par/workstealing/internal/ranges.scala
@@ -268,7 +268,7 @@ object RangesMacros {
 
     reify {
       ordv.splice
-      if (Configuration.manualOptimizations && (ordg.splice eq Ordering.Int)) {
+      if (Configuration.manualOptimizations && (ordg.splice eq scala.math.Ordering.Int)) {
         val range = calleeExpression.splice.r
         if (range.step > 0) range.head else range.last
       } else reduceResult.splice
@@ -285,7 +285,7 @@ object RangesMacros {
 
     reify {
       ordv.splice
-      if (Configuration.manualOptimizations && (ordg.splice eq Ordering.Int)) {
+      if (Configuration.manualOptimizations && (ordg.splice eq scala.math.Ordering.Int)) {
         val range = calleeExpression.splice.r
         if (range.step < 0) range.head else range.last
       } else reduceResult.splice

--- a/src/test/scala/org/scala/optimized/test/scalameter/OptimizedBlockBench.scala
+++ b/src/test/scala/org/scala/optimized/test/scalameter/OptimizedBlockBench.scala
@@ -13,9 +13,7 @@ class OptimizedBlockBench extends PerformanceTest.Regression with Serializable w
 
   def persistor = new SerializationPersistor
 
-  val tiny = 300000
-  val small = 3000000
-  val large = 30000000
+
 
   val opts = Seq(
     exec.minWarmupRuns -> 50,
@@ -35,6 +33,9 @@ class OptimizedBlockBench extends PerformanceTest.Regression with Serializable w
   /* benchmarks */
 
   performance of "Optimized[Range]" config (opts: _*) in {
+    val tiny = 300000
+    val small = 3000000
+    val large = 30000000
 
     measure method "reduce" in {
       using(ranges(large)) curve ("collections") in { x =>
@@ -66,16 +67,9 @@ class OptimizedBlockBench extends PerformanceTest.Regression with Serializable w
 
     measure method "filter" in {
       using(ranges(small)) curve ("collections") in { x =>
-        x.find(_>0)
+        x.filter(_>5)
       }
-      using(ranges(small)) curve ("optimized") in { x => optimize{x.filter(_>0)} }
-    }
-
-    measure method "forall" in {
-      using(ranges(large)) curve ("collections") in { x =>
-        x.forall(_>0)
-      }
-      using(ranges(large)) curve ("optimized") in { x => optimize{x.forall(_>0)} }
+      using(ranges(small)) curve ("optimized") in { x => optimize{x.filter(_>5)} }
     }
 
     measure method "flatMap" in {
@@ -137,24 +131,99 @@ class OptimizedBlockBench extends PerformanceTest.Regression with Serializable w
       }
     }
 
-    measure method "min" in {
-      using(ranges(large)) curve ("collections") in { x =>
-        x.min
+    measure method "ProjectEuler1" in {
+
+      using(ranges(small)) curve ("collections") in { x =>
+        x.filter(x => (x % 3 == 0)|| (x % 5 == 0)).reduce(_ + _)
       }
-      using(ranges(large)) curve ("optimized") in { x => 
-        optimize{x.min}
-      }
-    }
-    measure method "product" in {
-      using(ranges(large)) curve ("collections") in { x =>
-        x.product
-      }
-      using(ranges(large)) curve ("optimized") in { x => 
-        optimize{x.product}
+      using(ranges(small)) curve ("optimized") in { x => 
+        optimize{x.filter(x => (x % 3 == 0)|| (x % 5 == 0)).reduce(_ + _)}
       }
     }
 
   }
+
+
+  performance of "Optimized[ImmutableSet]" config (opts: _*) in {
+
+
+    val small = 25000
+    val large = 150000
+
+    measure method "reduce" in {
+      using(hashTrieSets(large)) curve ("collections") in { x =>
+        x.reduce(_+_)
+      }
+      using(hashTrieSets(large)) curve ("optimized") in { x => optimize{x.reduce(_+_)} }
+    }
+
+
+
+    measure method "map" in {
+      using(hashTrieSets(small)) curve ("collections") in { x =>
+        x.map(x=>x)
+      }
+      using(hashTrieSets(small)) curve ("optimized") in { x => optimize{x.map(x=>x)} }
+    }
+
+
+    measure method "exists" in {
+      using(hashTrieSets(large)) curve ("collections") in { x =>
+        x.exists(_<Int.MinValue)
+      }
+      using(hashTrieSets(large)) curve ("optimized") in { x => optimize{x.exists(_<Int.MinValue)} }
+    }
+
+    measure method "find" in {
+      using(hashTrieSets(large)) curve ("collections") in { x =>
+        x.find(_<Int.MinValue)
+      }
+      using(hashTrieSets(large)) curve ("optimized") in { x => optimize{x.find(_<Int.MinValue)} }
+    }
+
+    measure method "filter" in {
+      using(hashTrieSets(small)) curve ("collections") in { x =>
+        x.filter(_>5)
+      }
+      using(hashTrieSets(small)) curve ("optimized") in { x => optimize{x.filter(_>5)} }
+    }
+
+    measure method "flatMap" in {
+      using(hashTrieSets(small)) curve ("collections") in { x =>
+        x.flatMap(x=> List(x, x, x))
+      }
+      using(hashTrieSets(small)) curve ("optimized") in { x => optimize{x.flatMap(x=> List(x, x, x))} }
+    }
+
+    measure method "foreach" in {
+      using(hashTrieSets(large)) curve ("collections") in { x =>
+        var count = 0
+        x.foreach(x=> count = count + 1)
+      }
+      using(hashTrieSets(large)) curve ("optimized") in { x => 
+        var count = 0 
+        optimize{x.foreach(x=> count = count + 1) }
+      }
+    }
+
+    measure method "count" in {
+      using(hashTrieSets(large)) curve ("collections") in { x =>
+        x.count(_>0)
+      }
+      using(hashTrieSets(large)) curve ("optimized") in { x => 
+        optimize{x.count(_>0)}
+      }
+    }
+
+    measure method "fold" in {
+      using(hashTrieSets(large)) curve ("collections") in { x =>
+        x.fold(0)(_+_)
+      }
+      using(hashTrieSets(large)) curve ("optimized") in { x => 
+        optimize{x.fold(0)(_+_)}
+      }
+    }
  
 
+ }
 }

--- a/src/test/scala/org/scala/optimized/test/scalameter/OptimizedBlockBench.scala
+++ b/src/test/scala/org/scala/optimized/test/scalameter/OptimizedBlockBench.scala
@@ -226,4 +226,5 @@ class OptimizedBlockBench extends PerformanceTest.Regression with Serializable w
  
 
  }
+
 }

--- a/src/test/scala/org/scala/optimized/test/scalatest/OptimizedBlockTest.scala
+++ b/src/test/scala/org/scala/optimized/test/scalatest/OptimizedBlockTest.scala
@@ -187,6 +187,44 @@ class OptimizedBlockTest extends FunSuite {
     val elems = (0 until size).toArray
     val expected = elems.max
     val obtained = optimize { elems.max }
-    assert(obtained == expected) 
+    assert(obtained == expected)
+  }
+
+  test("Range->Array->Array->int") {
+    val size = 200000
+    val elems = 0 until size
+    val expected = elems.map(_ + 1).filter(_ % 2 == 0).sum
+    val obtained = optimize { elems.map(_ + 1).filter(_ % 2 == 0).sum}
+    assert(obtained == expected)
+  }
+
+  test("Range->(Range)->int") {
+    val size = 200
+    val elems = 0 until size
+    val expected = elems.flatMap(x => elems.map(_ + 1)).sum
+    val obtained = optimize { elems.flatMap(x => elems.map(_ + 1)).sum}
+    assert(obtained == expected)
+  }
+
+  test("Range->(Range->Array->Array)->Array->int") {
+    val size = 200
+    val elems = 0 until size
+    val expected = elems.flatMap(x => elems.map(_ + 1).filter(_ % 2 == x % 2)).filter(_ % 2 == 0).sum
+    val obtained = optimize { elems.flatMap(x => elems.map(_ + 1).filter(_ % 2 == x % 2)).filter(_ % 2 == 0).sum}
+    assert(obtained == expected)
+  }
+
+  test("Range->(Range->Array->Array)->Array->int, defs inside") {
+    val size = 200
+   
+    val expected = {
+      val elems = 0 until size
+      elems.flatMap(x => elems.map(_ + 1).filter(_ % 2 == x % 2)).filter(_ % 2 == 0).sum
+    }
+    val obtained = optimize {
+      val elems = 0 until size
+      elems.flatMap(x => elems.map(_ + 1).filter(_ % 2 == x % 2)).filter(_ % 2 == 0).sum
+    }
+    assert(obtained == expected)
   }
 }

--- a/src/test/scala/org/scala/optimized/test/scalatest/OptimizedBlockTest.scala
+++ b/src/test/scala/org/scala/optimized/test/scalatest/OptimizedBlockTest.scala
@@ -14,7 +14,7 @@ class OptimizedBlockTest extends FunSuite {
 
   import scala.collection._
 
-  test("foreach") {
+  test("Range.foreach") {
     val size = 200000
     val elems = 0 until size
     val expected = {
@@ -30,7 +30,7 @@ class OptimizedBlockTest extends FunSuite {
     assert(obtained == expected)
   }
 
-  test("map") {
+  test("Range.map") {
     val size = 200000
     val elems = 0 until size
     val expected = elems.map(_ + 1)
@@ -38,7 +38,7 @@ class OptimizedBlockTest extends FunSuite {
     assert(obtained.toSeq == expected.toSeq)
   }
 
-  test("filter") {
+  test("Range.filter") {
     val size = 200000
     val elems = 0 until size
     val expected = elems.filter(_ % 2 == 0)
@@ -46,7 +46,7 @@ class OptimizedBlockTest extends FunSuite {
     assert(obtained.toSeq == expected.toSeq)
   }
 
-  test("reduce") {
+  test("Range.reduce") {
     val size = 200000
     val elems = 0 until size
     val expected = elems.reduce(_ + _)
@@ -54,7 +54,7 @@ class OptimizedBlockTest extends FunSuite {
     assert(obtained == expected)
   }
 
-  test("flatMap") {
+  test("Range.flatMap") {
     val size = 200000
     val elems = 0 until size
     val expected = elems.flatMap(x => x to (x + 10))
@@ -62,7 +62,7 @@ class OptimizedBlockTest extends FunSuite {
     assert(obtained.toSeq == expected.toSeq)
   }
 
-  test("count") {
+  test("Range.count") {
     val size = 200000
     val elems = 0 until size
     val expected = elems.count(x => (x & 1) == 0)
@@ -70,7 +70,7 @@ class OptimizedBlockTest extends FunSuite {
     assert(obtained == expected)
   }
 
-  test("fold") {
+  test("Range.fold") {
     val size = 200000
     val elems = 0 until size
     val expected = elems.fold(0)(_ + _)
@@ -78,7 +78,7 @@ class OptimizedBlockTest extends FunSuite {
     assert(obtained == expected)
   }
 
-  test("sum") {
+  test("Range.sum") {
     val size = 200000
     val elems = 0 until size
     val expected = elems.sum
@@ -86,7 +86,7 @@ class OptimizedBlockTest extends FunSuite {
     assert(obtained == expected)
   }
 
-  test("min") {
+  test("Range.min") {
     val size = 200000
     val elems = 0 until size
     val expected = elems.min
@@ -94,11 +94,99 @@ class OptimizedBlockTest extends FunSuite {
     assert(obtained == expected)
   }
 
-  test("max") {
+  test("Range.max") {
     val size = 200000
     val elems = 0 until size
     val expected = elems.max
     val obtained = optimize { elems.max }
     assert(obtained == expected)
+  }
+
+  test("Array.foreach") {
+    val size = 200000
+    val elems = (0 until size).toArray
+    val expected = {
+      var count = 0
+      elems.foreach(x => count = count + x)
+      count
+    }
+    val obtained = {
+      var count = 0
+      optimize { elems.foreach(x => count = count + x) }
+      count
+    }
+    assert(obtained == expected)
+  }
+
+  test("Array.map") {
+    val size = 200000
+    val elems = (0 until size).toArray
+    val expected = elems.map(_ + 1)
+    val obtained = optimize { elems.map(_ + 1) }
+    assert(obtained.toSeq == expected.toSeq)
+  }
+
+  test("Array.filter") {
+    val size = 200000
+    val elems = (0 until size).toArray
+    val expected = elems.filter(_ % 2 == 0)
+    val obtained = optimize { elems.filter(_ % 2 == 0) }
+    assert(obtained.toSeq == expected.toSeq)
+  }
+
+  test("Array.reduce") {
+    val size = 200000
+    val elems = (0 until size).toArray
+    val expected = elems.reduce(_ + _)
+    val obtained = optimize { elems.reduce(_ + _) }
+    assert(obtained == expected)
+  }
+
+  test("Array.flatMap") {
+    val size = 200000
+    val elems = (0 until size).toArray
+    val expected = elems.flatMap(x => x to (x + 10))
+    val obtained = optimize { elems.flatMap(x => x to (x + 10)) }
+    assert(obtained.toSeq == expected.toSeq)
+  }
+
+  test("Array.count") {
+    val size = 200000
+    val elems = (0 until size).toArray
+    val expected = elems.count(x => (x & 1) == 0)
+    val obtained = optimize { elems.count(x => (x & 1) == 0) }
+    assert(obtained == expected)
+  }
+
+  test("Array.fold") {
+    val size = 200000
+    val elems = (0 until size).toArray
+    val expected = elems.fold(0)(_ + _)
+    val obtained = optimize { elems.fold(0)(_ + _) }
+    assert(obtained == expected)
+  }
+
+  test("Array.sum") {
+    val size = 200000
+    val elems = (0 until size).toArray
+    val expected = elems.sum
+    val obtained = optimize { elems.sum }
+    assert(obtained == expected)
+  }
+
+  test("Array.min") {
+    val size = 200000
+    val elems = (0 until size).toArray
+    val expected = elems.min
+    val obtained = optimize { elems.min }
+    assert(obtained == expected)
+  }
+
+  test("Array.max") {
+    val size = 200000
+    val elems = (0 until size).toArray
+    val expected = elems.max
+    val obtained = optimize { elems.max }
+    assert(obtained == expected) 
   }
 }

--- a/src/test/scala/org/scala/optimized/test/scalatest/OptimizedBlockTest.scala
+++ b/src/test/scala/org/scala/optimized/test/scalatest/OptimizedBlockTest.scala
@@ -202,7 +202,7 @@ class OptimizedBlockTest extends FunSuite {
     val size = 200
     val elems = 0 until size
     val expected = elems.flatMap(x => elems.map(_ + 1)).sum
-    val obtained = optimize { elems.flatMap(x => elems.map(_ + 1)).sum}
+    val obtained = optimize { elems.flatMap(x => elems.map(_ + 1)).sum }
     assert(obtained == expected)
   }
 
@@ -210,7 +210,7 @@ class OptimizedBlockTest extends FunSuite {
     val size = 200
     val elems = 0 until size
     val expected = elems.flatMap(x => elems.map(_ + 1).filter(_ % 2 == x % 2)).filter(_ % 2 == 0).sum
-    val obtained = optimize { elems.flatMap(x => elems.map(_ + 1).filter(_ % 2 == x % 2)).filter(_ % 2 == 0).sum}
+    val obtained = optimize { elems.flatMap(x => elems.map(_ + 1).filter(_ % 2 == x % 2)).filter(_ % 2 == 0).sum }
     assert(obtained == expected)
   }
 


### PR DESCRIPTION
Currently optimize block doesn't support arrays, as they are treated 'specially' by compiler(they don't have operations themselves and implicit conversion to ArrayOps is used to add operations).
This pull request adds rewrite rules to optimize block, that allow to use workstealing data-parallel operations implementations for scala arrays.
