### PR TITLE
IsZippable also provides an IsReducable

### DIFF
--- a/src/main/scala/scala/collection/par/generic/IsZippable.scala
+++ b/src/main/scala/scala/collection/par/generic/IsZippable.scala
@@ -6,6 +6,6 @@ import scala.collection.par.{Par, Zippable}
 
 
 
-trait IsZippable[Repr, T] {
+trait IsZippable[Repr, T] extends IsReducable[Repr, T]{
   def apply(r: Par[Repr]): Zippable[T]
 }


### PR DESCRIPTION
This simplifies use of many operations that require IsReducable, but Scope defined only isZippable, which should suffice. 
