### PR TITLE
Fix errors specific to 2.11

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -17,6 +17,7 @@ object BuildSettings {
       "org.scala-lang" % "scala-reflect" % "2.11.0"
       , "com.github.axel22" %% "scalameter" % "0.5-M2" % "test"
       , "org.scalatest" %% "scalatest" % "2.1.3" % "test"
+      , "org.scala-lang" % "scala-compiler" % "2.11.0"
     ),
     testFrameworks += new TestFramework("org.scalameter.ScalaMeterFramework"),
     logBuffered := false,

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -17,7 +17,7 @@ object BuildSettings {
       "org.scala-lang" % "scala-reflect" % "2.11.0"
       , "com.github.axel22" %% "scalameter" % "0.5-M2" % "test"
       , "org.scalatest" %% "scalatest" % "2.1.3" % "test"
-      , "org.scala-lang" % "scala-compiler" % "2.11.0"
+      , "org.scala-lang" % "scala-compiler" % "2.11.0" % "provided"
     ),
     testFrameworks += new TestFramework("org.scalameter.ScalaMeterFramework"),
     logBuffered := false,

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -16,6 +16,7 @@ object BuildSettings {
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-reflect" % "2.11.0"
       , "com.github.axel22" %% "scalameter" % "0.5-M2" % "test"
+      , "org.scalatest" %% "scalatest" % "2.1.3" % "test"
     ),
     testFrameworks += new TestFramework("org.scalameter.ScalaMeterFramework"),
     logBuffered := false,

--- a/src/main/scala/scala/collection/optimizer/package.scala
+++ b/src/main/scala/scala/collection/optimizer/package.scala
@@ -60,7 +60,8 @@ package object optimizer {
 
     val t = BoxUnboxEliminating.transform(exp.tree)
     if (echoSplicedCode) println(t)
-    (c.untypecheck(t))
+    val global = c.universe.asInstanceOf[scala.tools.nsc.Global]
+    global.brutallyResetAttrs(t.asInstanceOf[global.Tree]).asInstanceOf[c.Tree]
   }
   
 
@@ -248,7 +249,7 @@ package object optimizer {
       if (allTypesFound) q"optimize_postprocess{${addImports(t)}}"
       else addImports(q"optimize{$t}")
      debug(s"\n\n\n***********************************************************************************\nresult: $resultWithImports")
-
-    (c.untypecheck(resultWithImports))
+    val global = c.universe.asInstanceOf[scala.tools.nsc.Global]
+    global.brutallyResetAttrs(resultWithImports.asInstanceOf[global.Tree]).asInstanceOf[c.Tree]
   }
 }

--- a/src/main/scala/scala/collection/par/workstealing/internal/optimizer.scala
+++ b/src/main/scala/scala/collection/par/workstealing/internal/optimizer.scala
@@ -134,7 +134,8 @@ class Optimizer[C <: Context](val c: C) {
 
   def inlineAndReset[T](expr: c.Expr[T]): c.Expr[T] = {
     val inliner = new Inlining.Optimization
-    c.Expr[T](c untypecheck  inliner.transform(expr.tree))
+    val global = c.universe.asInstanceOf[scala.tools.nsc.Global]
+    c.Expr[T](global.brutallyResetAttrs(inliner.transform(expr.tree).asInstanceOf[global.Tree]).asInstanceOf[c.Tree])
   }
 
   /* fusion */
@@ -276,7 +277,8 @@ class Optimizer[C <: Context](val c: C) {
     val inltree = inlineFunctionApply(tree)
     val fustree = flatMapFusion(inltree)
     val opttree = fustree
-    c.Expr[T](c untypecheck  opttree)
+    val global = c.universe.asInstanceOf[scala.tools.nsc.Global]
+    c.Expr[T](global.brutallyResetAttrs(opttree.asInstanceOf[global.Tree]).asInstanceOf[c.Tree])
   }
 
 }

--- a/src/test/scala/org/scala/optimized/test/examples/Mandelbrot.scala
+++ b/src/test/scala/org/scala/optimized/test/examples/Mandelbrot.scala
@@ -14,10 +14,10 @@ import org.scalameter.{ Reporter, Gen, PerformanceTest }
 import org.scalameter.persistence.SerializationPersistor
 import org.scalameter.api._
 import org.scalameter.reporting.{ ChartReporter, HtmlReporter, RegressionReporter }
+import org.scalameter.PerformanceTest.OnlineRegressionReport
 
 
-
-object Mandelbrot extends PerformanceTest.Regression with Serializable {
+object Mandelbrot extends OnlineRegressionReport with Serializable {
 
   private def compute(xc: Double, yc: Double, threshold: Int): Int = {
     var i = 0
@@ -243,8 +243,6 @@ object Mandelbrot extends PerformanceTest.Regression with Serializable {
   override def main(args: Array[String]) {
     val frame = new MandelFrame
   }
-
-  lazy val persistor = new SerializationPersistor
 
   @volatile var dummy: Int = Int.MinValue;
 

--- a/src/test/scala/org/scala/optimized/test/scalameter/ConcBench.scala
+++ b/src/test/scala/org/scala/optimized/test/scalameter/ConcBench.scala
@@ -4,15 +4,11 @@ package scalameter
 
 import scala.collection.par._
 import org.scalameter.api._
+import org.scalameter.PerformanceTest.OnlineRegressionReport
 
 
-
-class ConcBench extends PerformanceTest.Regression with Serializable {
+class ConcBench extends OnlineRegressionReport with Serializable {
   import Scheduler.Config
-
-  /* config */
-
-  def persistor = new SerializationPersistor
 
   /* generators */
 
@@ -44,7 +40,7 @@ class ConcBench extends PerformanceTest.Regression with Serializable {
         var list: List[Unit] = Nil
         var i = 0
         while (i < sz) {
-          list ::= ()
+          list ::= (())
           i += 1
         }
       }
@@ -53,7 +49,7 @@ class ConcBench extends PerformanceTest.Regression with Serializable {
         var v = collection.immutable.Vector[Unit]()
         var i = 0
         while (i < sz) {
-          v = v :+ ()
+          v = v :+ (())
           i += 1
         }
       }
@@ -80,7 +76,7 @@ class ConcBench extends PerformanceTest.Regression with Serializable {
         val vb = new collection.immutable.VectorBuilder[Unit]()
         var i = 0
         while (i < sz) {
-          vb += ()
+          vb += (())
           i += 1
         }
       }
@@ -89,7 +85,7 @@ class ConcBench extends PerformanceTest.Regression with Serializable {
         val ab = new collection.mutable.ArrayBuffer[Unit]()
         var i = 0
         while (i < sz) {
-          ab += ()
+          ab += (())
           i += 1
         }
       }

--- a/src/test/scala/org/scala/optimized/test/scalameter/ConcMemory.scala
+++ b/src/test/scala/org/scala/optimized/test/scalameter/ConcMemory.scala
@@ -4,16 +4,15 @@ package scalameter
 
 import scala.collection.par._
 import org.scalameter.api._
+import org.scalameter.PerformanceTest.OnlineRegressionReport
 
 
-
-class ConcMemory extends PerformanceTest.Regression with Serializable {
+class ConcMemory extends OnlineRegressionReport with Serializable {
   import Scheduler.Config
 
   /* config */
 
   override def measurer = new Executor.Measurer.MemoryFootprint
-  def persistor = new SerializationPersistor
 
   /* generators */
 
@@ -34,7 +33,7 @@ class ConcMemory extends PerformanceTest.Regression with Serializable {
         var list: List[Unit] = Nil
         var i = 0
         while (i < sz) {
-          list ::= ()
+          list ::= (())
           i += 1
         }
         list
@@ -44,7 +43,7 @@ class ConcMemory extends PerformanceTest.Regression with Serializable {
         var v = collection.immutable.Vector[Unit]()
         var i = 0
         while (i < sz) {
-          v = v :+ ()
+          v = v :+ (())
           i += 1
         }
         v

--- a/src/test/scala/org/scala/optimized/test/scalameter/HashesBench.scala
+++ b/src/test/scala/org/scala/optimized/test/scalameter/HashesBench.scala
@@ -5,15 +5,13 @@ package scalameter
 
 import scala.collection.par._
 import org.scalameter.api._
+import org.scalameter.PerformanceTest.OnlineRegressionReport
 
 
-
-class HashesBench extends PerformanceTest.Regression with Serializable with Generators with scala.collection.parallel.scalatest.Helpers{
+class HashesBench extends OnlineRegressionReport with Serializable with Generators with scala.collection.parallel.scalatest.Helpers{
   import Scheduler.Config
 
   /* config */
-
-  def persistor = new SerializationPersistor
 
   val from = 3000000
 

--- a/src/test/scala/org/scala/optimized/test/scalameter/MathBench.scala
+++ b/src/test/scala/org/scala/optimized/test/scalameter/MathBench.scala
@@ -6,19 +6,20 @@ package scalameter
 import scala.collection.par._
 import org.scalameter.api._
 import scala.reflect.ClassTag
+import org.scalameter.PerformanceTest.OnlineRegressionReport
+import org.scalameter.{Key, KeyValue}
 
 
 
-class MathBench extends PerformanceTest.Regression with Serializable with Generators {
+class MathBench extends OnlineRegressionReport with Serializable with Generators {
 
   /* config */
 
-  def persistor = new SerializationPersistor
   val tiny =  100000
 
   /* generators */
 
-  val opts = Seq(
+  val opts = Context(
     exec.minWarmupRuns -> 50,
     exec.maxWarmupRuns -> 100,
     exec.benchRuns -> 48,
@@ -28,52 +29,56 @@ class MathBench extends PerformanceTest.Regression with Serializable with Genera
     reports.regression.noiseMagnitude -> 0.15)
 
 
-  performance of "Math" config (opts: _*) in {
-    measure method "Math" config (opts: _*) in {
-      using(ranges(tiny)) curve ("sin") in { x => 
-        var i = x.head
-        val to = x.end
-        var acc = 0.0
-	while(i<to) {
-          acc = acc + Math.sin(i)
-	  i = i + 1
-        }
-	acc
-      }
-      
-      using(ranges(tiny)) curve ("sqrt") in { x => 
-        var i = x.head
-        val to = x.end
-        var acc = 0.0
-	while(i<to) {
-          acc = acc + Math.sqrt(i)
-	  i = i + 1}
-	acc
+  performance of "Math" config (opts) in {
+    measure method "Math" config (opts) in {
+      using(ranges(tiny)) curve ("sin") in {
+        x =>
+          var i = x.head
+          val to = x.end
+          var acc = 0.0
+          while (i < to) {
+            acc = acc + Math.sin(i)
+            i = i + 1
+          }
+          acc
       }
 
-      using(ranges(tiny)) curve ("tan") in { x => 
-        var i = x.head
-        val to = x.end
-        var acc = 0.0
-	while(i<to) {
-          acc = acc + Math.tan(i)
-	  i = i + 1
-        }
-	acc
+      using(ranges(tiny)) curve ("sqrt") in {
+        x =>
+          var i = x.head
+          val to = x.end
+          var acc = 0.0
+          while (i < to) {
+            acc = acc + Math.sqrt(i)
+            i = i + 1
+          }
+          acc
       }
 
-      using(ranges(tiny)) curve ("baseline") in { x => 
-        var i = x.head
-        val to = x.end
-        var acc = 1.0
-	while(i<to) {
-          acc = acc + acc
-	  i = i + 1
-        }
-	acc
+      using(ranges(tiny)) curve ("tan") in {
+        x =>
+          var i = x.head
+          val to = x.end
+          var acc = 0.0
+          while (i < to) {
+            acc = acc + Math.tan(i)
+            i = i + 1
+          }
+          acc
       }
 
-      
+      using(ranges(tiny)) curve ("baseline") in {
+        x =>
+          var i = x.head
+          val to = x.end
+          var acc = 1.0
+          while (i < to) {
+            acc = acc + acc
+            i = i + 1
+          }
+          acc
+      }
+
 
     }
 

--- a/src/test/scala/org/scala/optimized/test/scalameter/OptimizedBlockBench.scala
+++ b/src/test/scala/org/scala/optimized/test/scalameter/OptimizedBlockBench.scala
@@ -15,7 +15,7 @@ class OptimizedBlockBench extends PerformanceTest.Regression with Serializable w
 
 
 
-  val opts = Seq(
+  val opts = Context(
     exec.minWarmupRuns -> 50,
     exec.maxWarmupRuns -> 100,
     exec.benchRuns -> 30,
@@ -23,7 +23,7 @@ class OptimizedBlockBench extends PerformanceTest.Regression with Serializable w
     exec.jvmflags -> "-server -Xms3072m -Xmx3072m -XX:MaxPermSize=256m -XX:ReservedCodeCacheSize=64m -XX:+UseCondCardMark -XX:CompileThreshold=100 -Dscala.collection.parallel.range.manual_optimizations=true",
     reports.regression.noiseMagnitude -> 0.15)
 
-  val pcopts = Seq(
+  val pcopts = Context(
     exec.minWarmupRuns -> 2,
     exec.maxWarmupRuns -> 4,
     exec.benchRuns -> 4,
@@ -32,7 +32,7 @@ class OptimizedBlockBench extends PerformanceTest.Regression with Serializable w
 
   /* benchmarks */
 
-  performance of "Optimized[Array]" config (opts: _*) in {
+  performance of "Optimized[Array]" config (opts) in {
 
     val small = 250000
     val large = 1500000
@@ -108,7 +108,7 @@ class OptimizedBlockBench extends PerformanceTest.Regression with Serializable w
     }
   }
 
-  performance of "Optimized[Range]" config (opts: _*) in {
+  performance of "Optimized[Range]" config (opts) in {
     val tiny = 300000
     val small = 3000000
     val large = 30000000
@@ -219,7 +219,7 @@ class OptimizedBlockBench extends PerformanceTest.Regression with Serializable w
 
   }
 
-  performance of "Optimized[ImmutableSet]" config (opts: _*) in {
+  performance of "Optimized[ImmutableSet]" config (opts) in {
 
     val small = 25000
     val large = 150000

--- a/src/test/scala/org/scala/optimized/test/scalameter/PageRank.scala
+++ b/src/test/scala/org/scala/optimized/test/scalameter/PageRank.scala
@@ -12,6 +12,7 @@ import org.scalameter.api._
 import scala.collection.parallel._
 import java.awt.Color
 import org.scalameter.reporting.{ ChartReporter, HtmlReporter, RegressionReporter }
+import org.scalameter.PerformanceTest.OnlineRegressionReport
 
 /**
  * Author: Dmitry Petrashko
@@ -20,11 +21,7 @@ import org.scalameter.reporting.{ ChartReporter, HtmlReporter, RegressionReporte
  * PageRank test
  */
 
-object PageRank extends PerformanceTest.Regression with Serializable with scalameter.Generators {
-
-  /* configuration */
-
-  lazy val persistor = new SerializationPersistor
+object PageRank extends OnlineRegressionReport with Serializable with scalameter.Generators {
 
   /* inputs */
 

--- a/src/test/scala/org/scala/optimized/test/scalameter/ParConcBench.scala
+++ b/src/test/scala/org/scala/optimized/test/scalameter/ParConcBench.scala
@@ -5,19 +5,17 @@ package scalameter
 import scala.collection.par._
 import org.scalameter.api._
 import scala.reflect.ClassTag
+import org.scalameter.PerformanceTest.OnlineRegressionReport
 
 
-
-class ParConcBench extends PerformanceTest.Regression with Serializable with ParConcSnippets with Generators {
+class ParConcBench extends OnlineRegressionReport with Serializable with ParConcSnippets with Generators {
 
   /* config */
-
-  def persistor = new SerializationPersistor
 
   val concFrom = 300000
   val bufferFrom = 10000000
 
-  val opts = Seq(
+  val opts = Context(
     exec.minWarmupRuns -> 25,
     exec.maxWarmupRuns -> 50,
     exec.benchRuns -> 48,
@@ -29,7 +27,7 @@ class ParConcBench extends PerformanceTest.Regression with Serializable with Par
 
   /* tests */
 
-  performance of "Par[Conc]" config(opts: _*) in { 
+  performance of "Par[Conc]" config(opts) in {
 
     measure method "reduce" in {
       using(arrays(bufferFrom)) curve("Array") in reduceSequential

--- a/src/test/scala/org/scala/optimized/test/scalameter/ParHashMapBench.scala
+++ b/src/test/scala/org/scala/optimized/test/scalameter/ParHashMapBench.scala
@@ -6,21 +6,19 @@ package scalameter
 import scala.collection.par._
 import org.scalameter.api._
 import scala.reflect.ClassTag
+import org.scalameter.PerformanceTest.OnlineRegressionReport
 
 
-
-class ParHashMapBench extends PerformanceTest.Regression with Serializable with ParHashMapSnippets with Generators {
+class ParHashMapBench extends OnlineRegressionReport with Serializable with ParHashMapSnippets with Generators {
   import Scheduler.Config
 
   /* config */
-
-  def persistor = new SerializationPersistor
 
   val tiny = 10000
   val small = 100000
   val normal = 300000
 
-  val opts = Seq(
+  val opts = Context(
     exec.minWarmupRuns -> 30,
     exec.maxWarmupRuns -> 60,
     exec.benchRuns -> 40,
@@ -32,7 +30,7 @@ class ParHashMapBench extends PerformanceTest.Regression with Serializable with 
 
   /* tests */
 
-  performance of "Par[HashMap]" config (opts: _*) in {
+  performance of "Par[HashMap]" config (opts) in {
 
     measure method "aggregate" in {
       using(hashMaps(normal)) curve ("Sequential") in aggregateSequential

--- a/src/test/scala/org/scala/optimized/test/scalameter/ParHashTrieSetBench.scala
+++ b/src/test/scala/org/scala/optimized/test/scalameter/ParHashTrieSetBench.scala
@@ -5,21 +5,19 @@ package scalameter
 import scala.collection.par._
 import org.scalameter.api._
 import scala.reflect.ClassTag
+import org.scalameter.PerformanceTest.OnlineRegressionReport
 
 
-
-class ParHashTrieSetBench extends PerformanceTest.Regression with Serializable with ParHashTrieSetSnippets with Generators {
+class ParHashTrieSetBench extends OnlineRegressionReport with Serializable with ParHashTrieSetSnippets with Generators {
   import Scheduler.Config
 
   /* config */
-
-  def persistor = new SerializationPersistor
 
   val tiny = 12500
   val small = 25000
   val normal = 150000
 
-  val opts = Seq(
+  val opts = Context(
     exec.minWarmupRuns -> 30,
     exec.maxWarmupRuns -> 60,
     exec.benchRuns -> 40,
@@ -32,7 +30,7 @@ class ParHashTrieSetBench extends PerformanceTest.Regression with Serializable w
 
   /* tests */
 
-  performance of "Par[immutable.HashSet]" config(opts: _*) in { 
+  performance of "Par[immutable.HashSet]" config(opts) in {
 
     measure method "aggregate" in {
       using(hashTrieSets(normal)) curve("Sequential") in aggregateSequential

--- a/src/test/scala/org/scala/optimized/test/scalameter/ParImmutableTreeSetBench.scala
+++ b/src/test/scala/org/scala/optimized/test/scalameter/ParImmutableTreeSetBench.scala
@@ -6,19 +6,17 @@ import scala.collection.par._
 import org.scalameter.api._
 import scala.reflect.ClassTag
 import Scheduler.Config
+import org.scalameter.PerformanceTest.OnlineRegressionReport
 
 
-
-class ParImmutableTreeSetBench extends PerformanceTest.Regression with Serializable with ParImmutableTreeSetSnippets with Generators {
+class ParImmutableTreeSetBench extends OnlineRegressionReport with Serializable with ParImmutableTreeSetSnippets with Generators {
 
 
   /* config */
 
-  def persistor = new SerializationPersistor
-
   val treesFrom = 6000
 
-  val opts = Seq(
+  val opts = Context(
     exec.minWarmupRuns -> 25,
     exec.maxWarmupRuns -> 50,
     exec.benchRuns -> 48,
@@ -30,7 +28,7 @@ class ParImmutableTreeSetBench extends PerformanceTest.Regression with Serializa
 
   /* tests */
 
-  performance of "Par[immutable.TreeSet]" config(opts: _*) in { 
+  performance of "Par[immutable.TreeSet]" config(opts) in {
 
     measure method "aggregate" in {
       using(withSchedulers(immutableTreeSets(treesFrom))) curve("immutable.TreeSet") in { t => 

--- a/src/test/scala/org/scala/optimized/test/scalameter/RayTracerBench.scala
+++ b/src/test/scala/org/scala/optimized/test/scalameter/RayTracerBench.scala
@@ -7,18 +7,14 @@ import scala.collection.par._
 import org.scalameter.api._
 import scala.reflect.ClassTag
 import org.scala.optimized.test.examples._
+import org.scalameter.PerformanceTest.OnlineRegressionReport
 
 
-
-class RayTracerBench extends PerformanceTest.Regression with Serializable with Generators {
-
-  /* config */
-
-  def persistor = new SerializationPersistor
+class RayTracerBench extends OnlineRegressionReport with Serializable with Generators {
 
   /* generators */
 
-  val opts = Seq(
+  val opts = Context(
     exec.minWarmupRuns -> 20,
     exec.maxWarmupRuns -> 100,
     exec.benchRuns -> 48,
@@ -27,7 +23,7 @@ class RayTracerBench extends PerformanceTest.Regression with Serializable with G
     exec.jvmflags -> "-server -Xms3072m -Xmx3072m -XX:MaxPermSize=256m -XX:ReservedCodeCacheSize=64m -XX:+UseCondCardMark -XX:CompileThreshold=100 -Dscala.collection.parallel.range.manual_optimizations=false",
     reports.regression.noiseMagnitude -> 0.15)
 
-  val oldopts = Seq(
+  val oldopts = Context(
     exec.minWarmupRuns -> 2,
     exec.maxWarmupRuns -> 4,
     exec.benchRuns -> 4,
@@ -36,9 +32,9 @@ class RayTracerBench extends PerformanceTest.Regression with Serializable with G
 
   /* benchmarks */
 
-  performance of "RayTracer" config (opts: _*) in {
+  performance of "RayTracer" config (opts) in {
 
-    measure method "trace" config (opts: _*) in {
+    measure method "trace" config (opts) in {
 
       def scenes = Gen.enumeration("scene")(RayTracer.scenes.keySet.toSeq: _*)
       

--- a/src/test/scala/org/scala/optimized/test/scalameter/ReducableBench.scala
+++ b/src/test/scala/org/scala/optimized/test/scalameter/ReducableBench.scala
@@ -5,14 +5,14 @@ package scalameter
 import scala.collection.par._
 import org.scalameter.api._
 import scala.reflect.ClassTag
+import org.scalameter.PerformanceTest.OnlineRegressionReport
+import org.scalameter.KeyValue
 
 
-
-class ReducableBench extends PerformanceTest.Regression with Serializable with ReducableSnippets with Generators {
+class ReducableBench extends OnlineRegressionReport with Serializable with ReducableSnippets with Generators {
 
   /* config */
 
-  def persistor = new SerializationPersistor
   val tiny =  60000
   val small = 600000
   val large = 1000000
@@ -21,7 +21,7 @@ class ReducableBench extends PerformanceTest.Regression with Serializable with R
 
   /* generators */
 
-  val opts = Seq(
+  val opts = Context(
     exec.minWarmupRuns -> 25,
     exec.maxWarmupRuns -> 50,
     exec.benchRuns -> 48,
@@ -30,7 +30,7 @@ class ReducableBench extends PerformanceTest.Regression with Serializable with R
     exec.jvmflags -> "-server -Xms3072m -Xmx3072m -XX:MaxPermSize=256m -XX:ReservedCodeCacheSize=64m -XX:+UseCondCardMark -XX:CompileThreshold=100 -Dscala.collection.parallel.range.manual_optimizations=false",
     reports.regression.noiseMagnitude -> 0.15)
 
-  val oldopts = Seq(
+  val oldopts = Context(
     exec.minWarmupRuns -> 2,
     exec.maxWarmupRuns -> 4,
     exec.benchRuns -> 4,
@@ -45,7 +45,7 @@ class ReducableBench extends PerformanceTest.Regression with Serializable with R
 
   /* benchmarks */
 
-  performance of "Reducables" config (opts: _*) in {
+  performance of "Reducables" config (opts) in {
 
     measure method "mapReduce" in {
       using(ranges(large)) curve ("Sequential") in mapReduceSequential

--- a/src/test/scala/org/scala/optimized/test/scalameter/benchmarks.scala
+++ b/src/test/scala/org/scala/optimized/test/scalameter/benchmarks.scala
@@ -3,14 +3,10 @@ package scalameter
 
 
 import org.scalameter.api._
+import org.scalameter.PerformanceTest.OnlineRegressionReport
 
 
-
-class benchmarks extends PerformanceTest.Regression with Serializable {
-
-  /* config */
-
-  def persistor = new SerializationPersistor
+class benchmarks extends OnlineRegressionReport with Serializable {
 
   /* tests */
 


### PR DESCRIPTION
Seems like we are hitting `resetLocalAttrs` very hard, and it needs to be fixed for our usecases.

For now I'm using hack to still be able to use `resetAllAttrs`.
