### PR TITLE
Sequential ops for lists

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -16,8 +16,9 @@ object BuildSettings {
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-reflect" % "2.11.0"
       , "com.github.axel22" %% "scalameter" % "0.5-M2" % "test"
-      , "org.scalatest" %% "scalatest" % "2.1.3" % "test"
-      , "org.scala-lang" % "scala-compiler" % "2.11.0" % "provided"
+      , "org.scalatest" %% "scalatest" % "2.1.5" % "test"
+      , "org.scala-lang" % "scala-compiler" % "2.11.0" % "provided",
+      "org.scalacheck" %% "scalacheck" % "1.11.4" % "test"
     ),
     testFrameworks += new TestFramework("org.scalameter.ScalaMeterFramework"),
     logBuffered := false,

--- a/src/main/scala/scala/collection/optimizer/Lists.scala
+++ b/src/main/scala/scala/collection/optimizer/Lists.scala
@@ -1,0 +1,40 @@
+package scala.collection.optimizer
+
+
+
+import scala.language.experimental.macros
+import scala.reflect.macros._
+import scala.reflect.ClassTag
+import scala.collection.par.generic._
+import scala.collection.par._
+import scala.collection.generic.CanBuildFrom
+import Scheduler.{Node, Ref}
+
+
+object Lists {
+
+  trait Scope {
+    implicit def ListOps[T](a: Optimized[List[T]]) = new Lists.Ops(a)
+  }
+
+  class Ops[T](val list: Optimized[List[T]]) {
+    def aggregate[S](z: S)(combop: (S, S) => S)(seqop: (S, T) => S): S = macro internal.ListMacros.aggregate[T,S]
+   /* def accumulate[S](merger: Merger[T, S]): S = ???
+    def foreach[U >: T](action: U => Unit): Unit = ???
+    def mapReduce[R](mapper: T => R)(reducer: (R, R) => R): R = ???
+    def reduce[U >: T](operator: (U, U) => U) = ???
+    def fold[U >: T](z: => U)(op: (U, U) => U): U = ???
+    def sum[U >: T](implicit num: Numeric[U]): U = ???
+    def product[U >: T](implicit num: Numeric[U]): U = ???
+    def min[U >: T](implicit ord: Ordering[U]): U = ???
+    def max[U >: T](implicit ord: Ordering[U]): U = ???
+    def find[U >: T](p: U => Boolean): Option[T] = ???
+    def exists[U >: T](p: U => Boolean): Boolean = ???
+    def forall[U >: T](p: U => Boolean): Boolean = ???
+    def count[U >: T](p: U => Boolean): Int = ???
+    def map[S, That](func: T => S)(implicit bf: CanBuildFrom[List[T], S, That]) = ???
+    def filter[That](pred: T => Boolean)(implicit bf: CanBuildFrom[List[T], T, That]) = ???
+    def flatMap[S, That](func: T => TraversableOnce[S])(implicit bf: CanBuildFrom[List[T], S, That]) = ???*/
+  }
+}
+

--- a/src/main/scala/scala/collection/optimizer/Lists.scala
+++ b/src/main/scala/scala/collection/optimizer/Lists.scala
@@ -19,7 +19,7 @@ object Lists {
 
   class Ops[T](val list: List[T]) extends AnyVal {
     def aggregate[S](z: S)(combop: (S, S) => S)(seqop: (S, T) => S): S = macro internal.ListMacros.aggregate[T,S]
-    def foreach[U >: T](action: U => Unit): Unit = macro internal.ListMacros.foreach[T, U]
+
     def mapReduce[R](mapper: T => R)(reducer: (R, R) => R): R = ???
     def reduce[U >: T](combop: (U, U) => U): U = macro internal.ListMacros.reduce[T, U]
     def fold[U >: T](z: => U)(op: (U, U) => U): U = macro internal.ListMacros.fold[T, U]
@@ -27,13 +27,16 @@ object Lists {
     def product[U >: T](implicit num: Numeric[U]): U = macro internal.ListMacros.product[T, U]
     def min[U >: T](implicit ord: Ordering[U]): U = macro internal.ListMacros.min[T, U]
     def max[U >: T](implicit ord: Ordering[U]): U = macro internal.ListMacros.max[T, U]
+
+    /* no gain from implementing as a macro before list is specialized
+    def foreach[U >: T](action: U => Unit): Unit = macro internal.ListMacros.foreach[T, U]
     def find[U >: T](p: U => Boolean): Option[T] = macro internal.ListMacros.find[T, U]
     def exists[U >: T](p: U => Boolean): Boolean = macro internal.ListMacros.exists[T, U]
     def forall[U >: T](p: U => Boolean): Boolean = macro internal.ListMacros.forall[T, U]
     def count[U >: T](p: U => Boolean): Int = macro internal.ListMacros.count[T, U]
     def map[S,  U >: T](p: U => S): List[S] = macro internal.ListMacros.map[T, U, S]
     def filter[That](p: T => Boolean): List[T] = macro internal.ListMacros.filter[T, T]
-    def flatMap[S,  U >: T](p: U => TraversableOnce[S]): List[S] = macro internal.ListMacros.flatMap[T, U, S]
+    def flatMap[S,  U >: T](p: U => TraversableOnce[S]): List[S] = macro internal.ListMacros.flatMap[T, U, S]*/
   }
 }
 

--- a/src/main/scala/scala/collection/optimizer/Lists.scala
+++ b/src/main/scala/scala/collection/optimizer/Lists.scala
@@ -14,15 +14,14 @@ import Scheduler.{Node, Ref}
 object Lists {
 
   trait Scope {
-    implicit def ListOps[T](a: Optimized[List[T]]) = new Lists.Ops(a)
+    implicit def ListOps[T](a: Optimized[List[T]]) = new Lists.Ops(a.seq)
   }
 
-  class Ops[T](val list: Optimized[List[T]]) {
+  class Ops[T](val list: List[T]) extends AnyVal {
     def aggregate[S](z: S)(combop: (S, S) => S)(seqop: (S, T) => S): S = macro internal.ListMacros.aggregate[T,S]
-   // def accumulate[S](merger: Merger[T, S]): S = ???
     def foreach[U >: T](action: U => Unit): Unit = macro internal.ListMacros.foreach[T, U]
     def mapReduce[R](mapper: T => R)(reducer: (R, R) => R): R = ???
-    def reduce[U >: T](combop: (U, U) => U) = macro internal.ListMacros.reduce[T, U]
+    def reduce[U >: T](combop: (U, U) => U): U = macro internal.ListMacros.reduce[T, U]
     def fold[U >: T](z: => U)(op: (U, U) => U): U = macro internal.ListMacros.fold[T, U]
     def sum[U >: T](implicit num: Numeric[U]): U = macro internal.ListMacros.sum[T, U]
     def product[U >: T](implicit num: Numeric[U]): U = macro internal.ListMacros.product[T, U]
@@ -31,10 +30,10 @@ object Lists {
     def find[U >: T](p: U => Boolean): Option[T] = macro internal.ListMacros.find[T, U]
     def exists[U >: T](p: U => Boolean): Boolean = macro internal.ListMacros.exists[T, U]
     def forall[U >: T](p: U => Boolean): Boolean = macro internal.ListMacros.forall[T, U]
-    def count[U >: T](p: U => Boolean): Int = ???
-    def map[S,  U >: T](p: U => S) = macro internal.ListMacros.map[T, U, S]
-    def filter[That](pred: T => Boolean) = ???
-    def flatMap[S,  U >: T](p: U => TraversableOnce[S]) = macro internal.ListMacros.flatMap[T, U, S]
+    def count[U >: T](p: U => Boolean): Int = macro internal.ListMacros.count[T, U]
+    def map[S,  U >: T](p: U => S): List[S] = macro internal.ListMacros.map[T, U, S]
+    def filter[That](p: T => Boolean): List[T] = macro internal.ListMacros.filter[T, T]
+    def flatMap[S,  U >: T](p: U => TraversableOnce[S]): List[S] = macro internal.ListMacros.flatMap[T, U, S]
   }
 }
 

--- a/src/main/scala/scala/collection/optimizer/Lists.scala
+++ b/src/main/scala/scala/collection/optimizer/Lists.scala
@@ -19,22 +19,22 @@ object Lists {
 
   class Ops[T](val list: Optimized[List[T]]) {
     def aggregate[S](z: S)(combop: (S, S) => S)(seqop: (S, T) => S): S = macro internal.ListMacros.aggregate[T,S]
-   /* def accumulate[S](merger: Merger[T, S]): S = ???
-    def foreach[U >: T](action: U => Unit): Unit = ???
+   // def accumulate[S](merger: Merger[T, S]): S = ???
+    def foreach[U >: T](action: U => Unit): Unit = macro internal.ListMacros.foreach[T, U]
     def mapReduce[R](mapper: T => R)(reducer: (R, R) => R): R = ???
-    def reduce[U >: T](operator: (U, U) => U) = ???
-    def fold[U >: T](z: => U)(op: (U, U) => U): U = ???
-    def sum[U >: T](implicit num: Numeric[U]): U = ???
-    def product[U >: T](implicit num: Numeric[U]): U = ???
-    def min[U >: T](implicit ord: Ordering[U]): U = ???
-    def max[U >: T](implicit ord: Ordering[U]): U = ???
-    def find[U >: T](p: U => Boolean): Option[T] = ???
-    def exists[U >: T](p: U => Boolean): Boolean = ???
-    def forall[U >: T](p: U => Boolean): Boolean = ???
+    def reduce[U >: T](combop: (U, U) => U) = macro internal.ListMacros.reduce[T, U]
+    def fold[U >: T](z: => U)(op: (U, U) => U): U = macro internal.ListMacros.fold[T, U]
+    def sum[U >: T](implicit num: Numeric[U]): U = macro internal.ListMacros.sum[T, U]
+    def product[U >: T](implicit num: Numeric[U]): U = macro internal.ListMacros.product[T, U]
+    def min[U >: T](implicit ord: Ordering[U]): U = macro internal.ListMacros.min[T, U]
+    def max[U >: T](implicit ord: Ordering[U]): U = macro internal.ListMacros.max[T, U]
+    def find[U >: T](p: U => Boolean): Option[T] = macro internal.ListMacros.find[T, U]
+    def exists[U >: T](p: U => Boolean): Boolean = macro internal.ListMacros.exists[T, U]
+    def forall[U >: T](p: U => Boolean): Boolean = macro internal.ListMacros.forall[T, U]
     def count[U >: T](p: U => Boolean): Int = ???
-    def map[S, That](func: T => S)(implicit bf: CanBuildFrom[List[T], S, That]) = ???
-    def filter[That](pred: T => Boolean)(implicit bf: CanBuildFrom[List[T], T, That]) = ???
-    def flatMap[S, That](func: T => TraversableOnce[S])(implicit bf: CanBuildFrom[List[T], S, That]) = ???*/
+    def map[S,  U >: T](p: U => S) = macro internal.ListMacros.map[T, U, S]
+    def filter[That](pred: T => Boolean) = ???
+    def flatMap[S,  U >: T](p: U => TraversableOnce[S]) = macro internal.ListMacros.flatMap[T, U, S]
   }
 }
 

--- a/src/main/scala/scala/collection/optimizer/Optimized.scala
+++ b/src/main/scala/scala/collection/optimizer/Optimized.scala
@@ -1,0 +1,8 @@
+package scala.collection.optimizer
+
+
+
+class Optimized[+Repr](val seq: Repr) {
+  override def toString = "Optimized(%s)".format(seq)
+}
+

--- a/src/main/scala/scala/collection/optimizer/Optimized.scala
+++ b/src/main/scala/scala/collection/optimizer/Optimized.scala
@@ -1,8 +1,17 @@
 package scala.collection.optimizer
 
 
-
-class Optimized[+Repr](val seq: Repr) {
+class Optimized[+Repr](val seq: Repr) extends AnyVal {
   override def toString = "Optimized(%s)".format(seq)
 }
+
+object Optimized {
+
+  class OptimizedOps[+Repr](val underlying: Repr) extends AnyVal {
+    override def toString = "OptimizedOps(%s)".format(underlying)
+    def opt = new Optimized(underlying)
+  }
+
+}
+
 

--- a/src/main/scala/scala/collection/optimizer/internal/lists.scala
+++ b/src/main/scala/scala/collection/optimizer/internal/lists.scala
@@ -1,0 +1,90 @@
+package scala.collection.optimizer.internal
+
+import scala.reflect.macros.blackbox.Context
+import scala.collection.optimizer.Lists
+import scala.language.experimental.macros
+import scala.reflect.macros._
+import scala.reflect.ClassTag
+import scala.collection.par.workstealing._
+import scala.collection.par.Scheduler
+import scala.collection.par.Scheduler.Node
+import scala.collection.par.generic._
+import scala.collection.par.Par
+import scala.collection.par.Merger
+
+import scala.collection.par.workstealing.internal.Optimizer
+
+
+object ListMacros {
+
+  class Optimizer[C <: Context](val c: C) {
+
+    import c.universe._
+
+    /** Returns the selection prefix of the current macro application.
+      */
+    def applyPrefix = c.macroApplication match {
+      case Apply(TypeApply(Select(prefix, name), targs), args) =>
+        prefix
+      case Apply(Apply(TypeApply(Select(prefix, name), targs), args1), args2) =>
+        prefix
+      case Apply(Apply(Apply(TypeApply(Select(prefix, name), targs), args1), args2), args3) =>
+        prefix
+      case Apply(Select(prefix, name), args) =>
+        prefix
+      case _ =>
+        c.prefix.tree
+    }
+
+    /** Used to generate a local val for a function expression,
+      * so that the function value is created only once.
+      *
+      * If `f` is a function literal, returns the literal.
+      * Otherwise, stores the function literal to a local value
+      * and returns a pair of the local value definition and an ident tree.
+      */
+    def nonFunctionToLocal[F](f: c.Expr[F], prefix: String = "local"): (c.Expr[Unit], c.Expr[F]) = f.tree match {
+      case Function(_, _) =>
+        (c.Expr[Unit](EmptyTree), c.Expr[F](f.tree))
+      case _ =>
+        val localname = TermName(c.freshName(prefix))
+        (c.Expr[Unit](ValDef(Modifiers(), localname, TypeTree(), f.tree)), c.Expr[F](Ident(localname)))
+    }
+  }
+
+
+  implicit def c2opt(c: Context) = new Optimizer[c.type](c)
+
+
+  def nonFunctionToLocal[F](c: Context)(f: c.Expr[F], prefix: String = "local"): (c.Expr[Unit], c.Expr[F]) = {
+
+    import c.universe._
+
+    f.tree match {
+      case Function(_, _) =>
+        (c.Expr[Unit](EmptyTree), c.Expr[F](f.tree))
+      case _ =>
+        val localname = TermName(c.freshName(prefix))
+        (c.Expr[Unit](ValDef(Modifiers(), localname, TypeTree(), f.tree)), c.Expr[F](Ident(localname)))
+    }
+  }
+
+
+  def aggregate[T: c.WeakTypeTag, S: c.WeakTypeTag](c: Context)(z: c.Expr[S])(combop: c.Expr[(S, S) => S])(seqop: c.Expr[(S, T) => S]): c.Expr[S] = {
+
+    import c.universe._
+
+    val (calleeExpressionv, calleeExpressiong) = c.nonFunctionToLocal[Lists.Ops[T]](c.Expr[Lists.Ops[T]](c.applyPrefix))
+    val t =
+      q"""$calleeExpressionv
+      var zero$$ = $z
+      val seqop$$ = $seqop
+      val comboop$$ = $combop
+      for(el <- $calleeExpressiong.list.seq) zero$$ = seqop$$(zero$$, el)
+      zero$$
+      """
+    println(t)
+    c.Expr[S](c.untypecheck(t))
+  }
+
+}

--- a/src/main/scala/scala/collection/optimizer/internal/lists.scala
+++ b/src/main/scala/scala/collection/optimizer/internal/lists.scala
@@ -11,205 +11,214 @@ import scala.collection.par.Scheduler.Node
 import scala.collection.par.generic._
 import scala.collection.par.Par
 import scala.collection.par.Merger
+import scala.collection.optimizer.zero
 
 import scala.collection.par.workstealing.internal.Optimizer.c2opt
 
 
 object ListMacros {
 
-  def mkAggregate[T: c.WeakTypeTag, S: c.WeakTypeTag](c: Context)(z: c.Expr[S])(combop: c.Expr[(S, S) => S])(seqop: c.Expr[(S, T) => S])(prefix: List[c.Expr[Any]]): c.Expr[S] = {
+  def mkAggregate[T: c.WeakTypeTag, S: c.WeakTypeTag](c: Context)(z: c.Expr[S])(combop: c.Expr[(S, S) => S])(seqop: c.Expr[(S, T) => S]): c.Tree = {
 
     import c.universe._
 
     val (calleeExpressionv, calleeExpressiong) = c.nonFunctionToLocal[Lists.Ops[T]](c.Expr[Lists.Ops[T]](c.applyPrefix))
+    val t = // val comboop = $combop
+      q"""
+      $calleeExpressionv
+      var zero = $z
+      var list = $calleeExpressiong.list.seq
+      while(list ne Nil) {
+        zero = $seqop(zero, list.head)
+        list = list.tail
+      }
+      zero
+      """
+    t
+  }
+
+  def reduce[T: c.WeakTypeTag, U >: T: c.WeakTypeTag](c: Context)(combop: c.Expr[(U, U) => U]): c.Expr[T] = {
+
+    import c.universe._
+
+    val (calleeExpressionv, calleeExpressiong) = c.nonFunctionToLocal[Lists.Ops[T]](c.Expr[Lists.Ops[T]](c.applyPrefix))
+    val (comboopv, comboopg) = c.nonFunctionToLocal[(U, U) => U](combop)
     val t =
       q"""
       $calleeExpressionv
-      $prefix
-      var zero = $z
-      val seqop = $seqop
-      val comboop = $combop
-      for(el <- $calleeExpressiong.list.seq) zero = seqop(zero, el)
+      $comboopv
+      var zero = $calleeExpressiong.list.seq.head
+      var list = $calleeExpressiong.list.seq.tail
+      while(list ne Nil) {
+        zero = $comboopg(zero, list.head)
+        list = list.tail
+      }
       zero
       """
-    c.Expr[S](c.untypecheck(t))
+    c.Expr[T](c.untypecheck(t))
   }
 
   def aggregate[T: c.WeakTypeTag, S: c.WeakTypeTag](c: Context)(z: c.Expr[S])(combop: c.Expr[(S, S) => S])(seqop: c.Expr[(S, T) => S]): c.Expr[S] =
-  mkAggregate(c)(z)(combop)(seqop)(Nil)
+    c.Expr[S](c.untypecheck(mkAggregate(c)(z)(combop)(seqop)))
 
   def fold[T: c.WeakTypeTag, U >: T: c.WeakTypeTag](c: Context)(z: c.Expr[U])(op: c.Expr[(U, U) => U]): c.Expr[U] = {
     aggregate(c)(z)(op)(op)
   }
 
-  def sum[T: c.WeakTypeTag, U >: T: c.WeakTypeTag](c: Context)(num: c.Expr[Numeric[U]], ctx: c.Expr[Scheduler]): c.Expr[U] = {
+  def sum[T: c.WeakTypeTag, U >: T: c.WeakTypeTag](c: Context)(num: c.Expr[Numeric[U]]): c.Expr[U] = {
     import c.universe._
     val (numv, numg) = c.nonFunctionToLocal[Numeric[U]](num)
     val op = c.Expr[(U, U)=>U](q"(x: U, y: U) => $numg.plus(x, y)")
-    mkAggregate(c)(c.Expr[U](q"$numg.zero"))(op)(op)(List(numv))
+    val zero = c.Expr[U](q"$numg.zero")
+    val t = q"""
+      $numv
+      ${mkAggregate(c)(zero)(op)(op)}
+      """
+    c.Expr[U](c.untypecheck(t))
+  }
+
+  def product[T: c.WeakTypeTag, U >: T: c.WeakTypeTag](c: Context)(num: c.Expr[Numeric[U]]): c.Expr[U] = {
+    import c.universe._
+    val (numv, numg) = c.nonFunctionToLocal[Numeric[U]](num)
+    val op = c.Expr[(U, U)=>U](q"(x: U, y: U) => $numg.times(x, y)")
+    val zero = c.Expr[U](q"$numg.one")
+    val t = q"""
+      $numv
+      ${mkAggregate(c)(zero)(op)(op)}
+      """
+    c.Expr[U](c.untypecheck(t))
   }
 
 
-    def foreach[T: c.WeakTypeTag, U >: T: c.WeakTypeTag](c: Context)(action: c.Expr[U=>Unit])(ctx: c.Expr[Scheduler]): c.Expr[Unit] = {
-      import c.universe._
+  def foreach[T: c.WeakTypeTag, U >: T : c.WeakTypeTag](c: Context)(action: c.Expr[U => Unit]): c.Expr[Unit] = {
+    import c.universe._
 
-      val (actionv, actiong) = c.nonFunctionToLocal[U => Unit](action)
-      val init = q"a: U => $actiong.apply(a)"
-      val fakeComboop = c.Expr[(Unit, Unit) => Unit](q"(x:Unit, a:Unit)=> x")
-      val seqoper = c.Expr[(Unit, U) => Unit](q"(x:Unit, a:U)=> $actiong.apply(a)")
-      val zero = c.Expr[Unit](q"()")
-      mkAggregate(c)(zero)(fakeComboop)(seqoper)(List(actionv))
-    }
+    val (actionv, actiong) = c.nonFunctionToLocal[U => Unit](action)
+    val fakeComboop = c.Expr[(Unit, Unit) => Unit](q"(x: Unit, a: Unit)=> x")
+    val seqoper = c.Expr[(Unit, U) => Unit](q"(x: Unit, a: U)=> $actiong.apply(a)")
+    val zero = c.Expr[Unit](q"()")
+    val t = q"""
+      $actionv
+      ${mkAggregate(c)(zero)(fakeComboop)(seqoper)}
+      """
+    c.Expr[Unit](c.untypecheck(t))
+  }
 
-  /*
-      def product[T: c.WeakTypeTag, U >: T: c.WeakTypeTag](c: BlackboxContext)(num: c.Expr[Numeric[U]], ctx: c.Expr[Scheduler]): c.Expr[U] = {
-        import c.universe._
+  def count[T: c.WeakTypeTag, U >: T: c.WeakTypeTag](c: Context)(p: c.Expr[U => Boolean]): c.Expr[Int] = {
+    import c.universe._
 
-        val (numv, numg) = c.nonFunctionToLocal[Numeric[U]](num)
-        val (zerov, zerog) = c.nonFunctionToLocal[U](reify {
-          numg.splice.one
-        })
-        val op = reify {
-          (x: U, y: U) => numg.splice.times(x, y)
-        }
-        val (lv, oper: c.Expr[(U, U) => U]) = c.nonFunctionToLocal[(U, U) => U](op)
-        val calleeExpression = c.Expr[Ranges.Ops](c.applyPrefix)
-        val init = c.universe.reify { a: U => a }
-        invokeAggregateKernel[T, U](c)(lv, numv, zerov)(zerog)(oper)(aggregateN[T, U](c)(init, oper))(ctx)
-      }
+    val comboop = c.Expr[(Int, Int) => Int](q"(x: Int, a: Int)=> x + a")
+    val (opv, opg) = c.nonFunctionToLocal[U => Boolean](p)
+    val seqoper = c.Expr[(Int, U) => Int](q"(x: Int, a: U)=> if($opg(a)) x + 1 else x")
+    val zero = c.Expr[Int](q"0")
+    val t = q"""
+      $opv
+      ${mkAggregate(c)(zero)(comboop)(seqoper)}
+      """
+    c.Expr[Int](c.untypecheck(t))
+  }
 
-      def count[T: c.WeakTypeTag, U >: T: c.WeakTypeTag](c: BlackboxContext)(p: c.Expr[U => Boolean])(ctx: c.Expr[Scheduler]): c.Expr[Int] = {
-        import c.universe._
+  def min[T: c.WeakTypeTag, U >: T: c.WeakTypeTag](c: Context)(ord: c.Expr[Ordering[U]]): c.Expr[T] = {
+    import c.universe._
 
-        val (predicv, predic) = c.nonFunctionToLocal[T => Boolean](p)
-        val zero = reify { 0 }
-        val combop = reify {
-          (x: Int, y: Int) => x + y
-        }
-        val seqop = reify {
-          (x: Int, y: T) =>
-            if (predic.splice(y)) x + 1 else x
-        }
-        val (seqlv, seqoper) = c.nonFunctionToLocal[(Int, T) => Int](seqop)
-        val (comblv, comboper) = c.nonFunctionToLocal[(Int, Int) => Int](combop)
-        val init = c.universe.reify { a: T => if (predic.splice(a)) 1 else 0; }
-        invokeAggregateKernel[T, Int](c)(predicv, seqlv, comblv)(zero)(comboper)(aggregateN[T, Int](c)(init, seqoper))(ctx)
-      }
+    val (ordv, ordg) = c.nonFunctionToLocal[Ordering[U]](ord)
+    val op = c.Expr[(T, T) => T](q"(x: U, y: U) => if ($ordg.compare(x, y) < 0) x else y ")
+    val red = reduce[T, T](c)(op)
+    c.Expr[T](q"""
+      $ordv
+      $red
+      """
+    )
+  }
 
-      def aggregateN[T: c.WeakTypeTag, R: c.WeakTypeTag](c: BlackboxContext)(init: c.Expr[T => R], oper: c.Expr[(R, T) => R]) = c.universe.reify { (from: Int, to: Int, kernel: Arrays.ArrayKernel[T,R], arr: Array[T]) =>
-      {
-        if (from > to) kernel.zero
-        else {
-          var i = from + 1
-          var sum: R = init.splice.apply(arr(from))
+  def max[T: c.WeakTypeTag, U >: T: c.WeakTypeTag](c: Context)(ord: c.Expr[Ordering[U]]): c.Expr[T] = {
+    import c.universe._
+    val tt = implicitly[c.WeakTypeTag[T]]
+    val (ordv, ordg) = c.nonFunctionToLocal[Ordering[U]](ord)
+    val op = c.Expr[(T, T) => T](q"(x: U, y: U) => if ($ordg.compare(x, y) > 0) x else y ")
+    val red = reduce[T, T](c)(op)
+    c.Expr[T](q"""
+      $ordv
+      $red
+      """
+    )
+  }
+  def find[T: c.WeakTypeTag, U >: T: c.WeakTypeTag](c: Context)(p: c.Expr[U => Boolean]): c.Expr[Option[T]] = {
+    import c.universe._
+    val tt = implicitly[c.WeakTypeTag[T]]
+    val z = zero(c)(tt.tpe)
+    val (pv, pg) = c.nonFunctionToLocal[U => Boolean](p)
+    val op = c.Expr[(Boolean, T) => Boolean](q"(x: Boolean, y: T) => x || {if ($pg(y)) {fndVal = y; true} else false}")
+    val fakeComboop = c.Expr[(Boolean, Boolean) => Boolean](q"(x: Boolean, y: Boolean)=> x || y")
+    val search = mkAggregate[T, Boolean](c)(c.Expr[Boolean](q"false"))(fakeComboop)(op)
+    c.Expr[Option[T]](q"""
+      $pv
+      var fndVal = $z
+      val found = $search
+      if(found) Some(fndVal) else None
+      """
+    )
+  }
 
-          while (i < to) {
-            sum = oper.splice(sum, arr(i))
-            i += 1
-          }
-          sum
-        }
-      }
-      }
+  def forall[T: c.WeakTypeTag, U >: T: c.WeakTypeTag](c: Context)(p: c.Expr[U => Boolean]): c.Expr[Boolean] = {
+    import c.universe._
+    val (pv, pg) = c.nonFunctionToLocal[U => Boolean](p)
+    val op = c.Expr[(Boolean, T) => Boolean](q"(x: Boolean, y: T) => x || {if (!$pg(y)) {true} else false}")
+    val fakeComboop = c.Expr[(Boolean, Boolean) => Boolean](q"(x: Boolean, y: Boolean)=> x || y")
+    val search = mkAggregate[T, Boolean](c)(c.Expr[Boolean](q"false"))(fakeComboop)(op)
+    c.Expr[Boolean](q"""
+      $pv
+      $search
+      """
+    )
+  }
 
-      def min[T: c.WeakTypeTag, U >: T: c.WeakTypeTag](c: BlackboxContext)(ord: c.Expr[Ordering[U]], ctx: c.Expr[Scheduler]): c.Expr[T] = {
-        import c.universe._
+  def exists[T: c.WeakTypeTag, U >: T: c.WeakTypeTag](c: Context)(p: c.Expr[U => Boolean]): c.Expr[Boolean] = {
+    import c.universe._
+    val (pv, pg) = c.nonFunctionToLocal[U => Boolean](p)
+    val op = c.Expr[(Boolean, T) => Boolean](q"(x: Boolean, y: T) => x || {if ($pg(y)) {true} else false}")
+    val fakeComboop = c.Expr[(Boolean, Boolean) => Boolean](q"(x: Boolean, y: Boolean)=> x || y")
+    val search = mkAggregate[T, Boolean](c)(c.Expr[Boolean](q"false"))(fakeComboop)(op)
+    c.Expr[Boolean](q"""
+      $pv
+      $search
+      """
+    )
+  }
 
-        val (ordv, ordg) = c.nonFunctionToLocal[Ordering[U]](ord)
-        val op = reify { (x: T, y: T) => if (ordg.splice.compare(x, y) < 0) x else y }
-        reify {
-          ordv.splice
-          reduce[T, T](c)(op)(ctx).splice
-        }
-      }
+  def map[T: c.WeakTypeTag, U >: T: c.WeakTypeTag, T2: c.WeakTypeTag](c: Context)(p: c.Expr[U => T2]): c.Expr[List[T2]] = {
+    import c.universe._
+    val z = c.Expr[scala.collection.mutable.ListBuffer[T2]](q"new scala.collection.mutable.ListBuffer()")
+    val (pv, pg) = c.nonFunctionToLocal[U => T2](p)
+    val op = c.Expr[(scala.collection.mutable.ListBuffer[T2], T) => scala.collection.mutable.ListBuffer[T2]](
+      q"(x: scala.collection.mutable.ListBuffer, y: T) => {x += $pg(y); x}"
+    )
+    val fakeComboop = c.Expr[(scala.collection.mutable.ListBuffer[T2], scala.collection.mutable.ListBuffer[T2]) => scala.collection.mutable.ListBuffer[T2]](
+      q"(x: scala.collection.mutable.ListBuffer, y:scala.collection.mutable.ListBuffer)=> x"
+    )
+    val mapper = mkAggregate[T, scala.collection.mutable.ListBuffer[T2]](c)(z)(fakeComboop)(op)
+    c.Expr[List[T2]](q"""
+      $pv
+      $mapper.toList
+      """
+    )
+  }
 
-      def max[T: c.WeakTypeTag, U >: T: c.WeakTypeTag](c: BlackboxContext)(ord: c.Expr[Ordering[U]], ctx: c.Expr[Scheduler]): c.Expr[T] = {
-        import c.universe._
-
-        val (ordv, ordg) = c.nonFunctionToLocal[Ordering[U]](ord)
-        val op = reify { (x: T, y: T) => if (ordg.splice.compare(x, y) > 0) x else y }
-        reify {
-          ordv.splice
-          reduce[T, T](c)(op)(ctx).splice
-        }
-      }
-
-      def findIndex[T: c.WeakTypeTag, U >: T: c.WeakTypeTag](c: BlackboxContext)(calleeExpr: c.Expr[Arrays.Ops[T]])(p: c.Expr[U => Boolean])(ctx: c.Expr[Scheduler]): c.Expr[Option[Int]] = {
-        import c.universe._
-
-        val (lv, pred) = c.nonFunctionToLocal[U => Boolean](p)
-
-        val result = reify {
-          import scala._
-          import collection.par
-          import par._
-          import workstealing._
-          import internal._
-          import scala.collection.par
-          lv.splice
-          val callee = calleeExpr.splice
-          val stealer = callee.stealer
-          val kernel = new scala.collection.par.workstealing.Arrays.ArrayKernel[T, Option[Int]] {
-            def zero = None
-            def combine(a: Option[Int], b: Option[Int]) = if (a.isDefined) a else b
-            def apply(node: Node[T, Option[Int]], from: Int, to: Int) = {
-              var i = from
-
-              val arr = callee.array.seq
-              while (i < to && !pred.splice(arr(i))) {
-                i += 1
-              }
-              if (i < to) {
-                setTerminationCause(ResultFound)
-                Some(i)
-              }
-              else None
-            }
-          }
-          val result = ctx.splice.invokeParallelOperation(stealer, kernel)
-          result
-        }
-        c.inlineAndReset(result)
-      }
-
-      def find[T: c.WeakTypeTag, U >: T: c.WeakTypeTag](c: BlackboxContext)(p: c.Expr[U => Boolean])(ctx: c.Expr[Scheduler]): c.Expr[Option[T]] = {
-        import c.universe._
-
-        val (calleeExpressionv, calleeExpressiong) = c.nonFunctionToLocal(c.Expr[Arrays.Ops[T]](c.applyPrefix))
-        val found = findIndex[T, T](c)(calleeExpressiong)(p)(ctx)
-        reify {
-          calleeExpressionv.splice
-          val mayBeIndex = found.splice
-          val result =
-            if (mayBeIndex.isDefined) Some(calleeExpressiong.splice.array.seq(mayBeIndex.get))
-            else None
-          result
-        }
-      }
-
-      def forall[T: c.WeakTypeTag, U >: T: c.WeakTypeTag](c: BlackboxContext)(p: c.Expr[U => Boolean])(ctx: c.Expr[Scheduler]): c.Expr[Boolean] = {
-        import c.universe._
-
-        val (calleeExpressionv, calleeExpressiong) = c.nonFunctionToLocal(c.Expr[Arrays.Ops[T]](c.applyPrefix))
-        val np = reify {
-          (x: T) => !p.splice(x)
-        }
-        val found = findIndex[T, T](c)(calleeExpressiong)(np)(ctx)
-        reify {
-          calleeExpressionv.splice
-          found.splice.isEmpty
-        }
-      }
-
-      def exists[T: c.WeakTypeTag, U >: T: c.WeakTypeTag](c: BlackboxContext)(p: c.Expr[U => Boolean])(ctx: c.Expr[Scheduler]): c.Expr[Boolean] = {
-        import c.universe._
-
-        val (calleeExpressionv, calleeExpressiong) = c.nonFunctionToLocal(c.Expr[Arrays.Ops[T]](c.applyPrefix))
-        val found = findIndex[T, U](c)(calleeExpressiong)(p)(ctx)
-        reify {
-          calleeExpressionv.splice
-          found.splice.nonEmpty
-        }
-      }
-    */
+  def flatMap[T: c.WeakTypeTag, U >: T: c.WeakTypeTag, T2: c.WeakTypeTag](c: Context)(p: c.Expr[U => TraversableOnce[T2]]): c.Expr[List[T2]] = {
+    import c.universe._
+    val z = c.Expr[scala.collection.mutable.ListBuffer[T2]](q"new scala.collection.mutable.ListBuffer()")
+    val (pv, pg) = c.nonFunctionToLocal[U => TraversableOnce[T2]](p)
+    val op = c.Expr[(scala.collection.mutable.ListBuffer[T2], T) => scala.collection.mutable.ListBuffer[T2]](
+      q"(x: scala.collection.mutable.ListBuffer, y: T) => {x ++= pg(y); x}"
+    )
+    val fakeComboop = c.Expr[(scala.collection.mutable.ListBuffer[T2], scala.collection.mutable.ListBuffer[T2]) => scala.collection.mutable.ListBuffer[T2]](
+      q"(x: scala.collection.mutable.ListBuffer, y:scala.collection.mutable.ListBuffer)=> x"
+    )
+    val mapper = mkAggregate[T, scala.collection.mutable.ListBuffer[T2]](c)(z)(fakeComboop)(op)
+    c.Expr[List[T2]](q"""
+      $pv
+      $mapper.toList
+      """
+    )
+  }
 }

--- a/src/main/scala/scala/collection/optimizer/internal/lists.scala
+++ b/src/main/scala/scala/collection/optimizer/internal/lists.scala
@@ -12,79 +12,204 @@ import scala.collection.par.generic._
 import scala.collection.par.Par
 import scala.collection.par.Merger
 
-import scala.collection.par.workstealing.internal.Optimizer
+import scala.collection.par.workstealing.internal.Optimizer.c2opt
 
 
 object ListMacros {
 
-  class Optimizer[C <: Context](val c: C) {
-
-    import c.universe._
-
-    /** Returns the selection prefix of the current macro application.
-      */
-    def applyPrefix = c.macroApplication match {
-      case Apply(TypeApply(Select(prefix, name), targs), args) =>
-        prefix
-      case Apply(Apply(TypeApply(Select(prefix, name), targs), args1), args2) =>
-        prefix
-      case Apply(Apply(Apply(TypeApply(Select(prefix, name), targs), args1), args2), args3) =>
-        prefix
-      case Apply(Select(prefix, name), args) =>
-        prefix
-      case _ =>
-        c.prefix.tree
-    }
-
-    /** Used to generate a local val for a function expression,
-      * so that the function value is created only once.
-      *
-      * If `f` is a function literal, returns the literal.
-      * Otherwise, stores the function literal to a local value
-      * and returns a pair of the local value definition and an ident tree.
-      */
-    def nonFunctionToLocal[F](f: c.Expr[F], prefix: String = "local"): (c.Expr[Unit], c.Expr[F]) = f.tree match {
-      case Function(_, _) =>
-        (c.Expr[Unit](EmptyTree), c.Expr[F](f.tree))
-      case _ =>
-        val localname = TermName(c.freshName(prefix))
-        (c.Expr[Unit](ValDef(Modifiers(), localname, TypeTree(), f.tree)), c.Expr[F](Ident(localname)))
-    }
-  }
-
-
-  implicit def c2opt(c: Context) = new Optimizer[c.type](c)
-
-
-  def nonFunctionToLocal[F](c: Context)(f: c.Expr[F], prefix: String = "local"): (c.Expr[Unit], c.Expr[F]) = {
-
-    import c.universe._
-
-    f.tree match {
-      case Function(_, _) =>
-        (c.Expr[Unit](EmptyTree), c.Expr[F](f.tree))
-      case _ =>
-        val localname = TermName(c.freshName(prefix))
-        (c.Expr[Unit](ValDef(Modifiers(), localname, TypeTree(), f.tree)), c.Expr[F](Ident(localname)))
-    }
-  }
-
-
-  def aggregate[T: c.WeakTypeTag, S: c.WeakTypeTag](c: Context)(z: c.Expr[S])(combop: c.Expr[(S, S) => S])(seqop: c.Expr[(S, T) => S]): c.Expr[S] = {
+  def mkAggregate[T: c.WeakTypeTag, S: c.WeakTypeTag](c: Context)(z: c.Expr[S])(combop: c.Expr[(S, S) => S])(seqop: c.Expr[(S, T) => S])(prefix: List[c.Expr[Any]]): c.Expr[S] = {
 
     import c.universe._
 
     val (calleeExpressionv, calleeExpressiong) = c.nonFunctionToLocal[Lists.Ops[T]](c.Expr[Lists.Ops[T]](c.applyPrefix))
     val t =
-      q"""$calleeExpressionv
-      var zero$$ = $z
-      val seqop$$ = $seqop
-      val comboop$$ = $combop
-      for(el <- $calleeExpressiong.list.seq) zero$$ = seqop$$(zero$$, el)
-      zero$$
+      q"""
+      $calleeExpressionv
+      $prefix
+      var zero = $z
+      val seqop = $seqop
+      val comboop = $combop
+      for(el <- $calleeExpressiong.list.seq) zero = seqop(zero, el)
+      zero
       """
-    println(t)
     c.Expr[S](c.untypecheck(t))
   }
 
+  def aggregate[T: c.WeakTypeTag, S: c.WeakTypeTag](c: Context)(z: c.Expr[S])(combop: c.Expr[(S, S) => S])(seqop: c.Expr[(S, T) => S]): c.Expr[S] =
+  mkAggregate(c)(z)(combop)(seqop)(Nil)
+
+  def fold[T: c.WeakTypeTag, U >: T: c.WeakTypeTag](c: Context)(z: c.Expr[U])(op: c.Expr[(U, U) => U]): c.Expr[U] = {
+    aggregate(c)(z)(op)(op)
+  }
+
+  def sum[T: c.WeakTypeTag, U >: T: c.WeakTypeTag](c: Context)(num: c.Expr[Numeric[U]], ctx: c.Expr[Scheduler]): c.Expr[U] = {
+    import c.universe._
+    val (numv, numg) = c.nonFunctionToLocal[Numeric[U]](num)
+    val op = c.Expr[(U, U)=>U](q"(x: U, y: U) => $numg.plus(x, y)")
+    mkAggregate(c)(c.Expr[U](q"$numg.zero"))(op)(op)(List(numv))
+  }
+
+
+    def foreach[T: c.WeakTypeTag, U >: T: c.WeakTypeTag](c: Context)(action: c.Expr[U=>Unit])(ctx: c.Expr[Scheduler]): c.Expr[Unit] = {
+      import c.universe._
+
+      val (actionv, actiong) = c.nonFunctionToLocal[U => Unit](action)
+      val init = q"a: U => $actiong.apply(a)"
+      val fakeComboop = c.Expr[(Unit, Unit) => Unit](q"(x:Unit, a:Unit)=> x")
+      val seqoper = c.Expr[(Unit, U) => Unit](q"(x:Unit, a:U)=> $actiong.apply(a)")
+      val zero = c.Expr[Unit](q"()")
+      mkAggregate(c)(zero)(fakeComboop)(seqoper)(List(actionv))
+    }
+
+  /*
+      def product[T: c.WeakTypeTag, U >: T: c.WeakTypeTag](c: BlackboxContext)(num: c.Expr[Numeric[U]], ctx: c.Expr[Scheduler]): c.Expr[U] = {
+        import c.universe._
+
+        val (numv, numg) = c.nonFunctionToLocal[Numeric[U]](num)
+        val (zerov, zerog) = c.nonFunctionToLocal[U](reify {
+          numg.splice.one
+        })
+        val op = reify {
+          (x: U, y: U) => numg.splice.times(x, y)
+        }
+        val (lv, oper: c.Expr[(U, U) => U]) = c.nonFunctionToLocal[(U, U) => U](op)
+        val calleeExpression = c.Expr[Ranges.Ops](c.applyPrefix)
+        val init = c.universe.reify { a: U => a }
+        invokeAggregateKernel[T, U](c)(lv, numv, zerov)(zerog)(oper)(aggregateN[T, U](c)(init, oper))(ctx)
+      }
+
+      def count[T: c.WeakTypeTag, U >: T: c.WeakTypeTag](c: BlackboxContext)(p: c.Expr[U => Boolean])(ctx: c.Expr[Scheduler]): c.Expr[Int] = {
+        import c.universe._
+
+        val (predicv, predic) = c.nonFunctionToLocal[T => Boolean](p)
+        val zero = reify { 0 }
+        val combop = reify {
+          (x: Int, y: Int) => x + y
+        }
+        val seqop = reify {
+          (x: Int, y: T) =>
+            if (predic.splice(y)) x + 1 else x
+        }
+        val (seqlv, seqoper) = c.nonFunctionToLocal[(Int, T) => Int](seqop)
+        val (comblv, comboper) = c.nonFunctionToLocal[(Int, Int) => Int](combop)
+        val init = c.universe.reify { a: T => if (predic.splice(a)) 1 else 0; }
+        invokeAggregateKernel[T, Int](c)(predicv, seqlv, comblv)(zero)(comboper)(aggregateN[T, Int](c)(init, seqoper))(ctx)
+      }
+
+      def aggregateN[T: c.WeakTypeTag, R: c.WeakTypeTag](c: BlackboxContext)(init: c.Expr[T => R], oper: c.Expr[(R, T) => R]) = c.universe.reify { (from: Int, to: Int, kernel: Arrays.ArrayKernel[T,R], arr: Array[T]) =>
+      {
+        if (from > to) kernel.zero
+        else {
+          var i = from + 1
+          var sum: R = init.splice.apply(arr(from))
+
+          while (i < to) {
+            sum = oper.splice(sum, arr(i))
+            i += 1
+          }
+          sum
+        }
+      }
+      }
+
+      def min[T: c.WeakTypeTag, U >: T: c.WeakTypeTag](c: BlackboxContext)(ord: c.Expr[Ordering[U]], ctx: c.Expr[Scheduler]): c.Expr[T] = {
+        import c.universe._
+
+        val (ordv, ordg) = c.nonFunctionToLocal[Ordering[U]](ord)
+        val op = reify { (x: T, y: T) => if (ordg.splice.compare(x, y) < 0) x else y }
+        reify {
+          ordv.splice
+          reduce[T, T](c)(op)(ctx).splice
+        }
+      }
+
+      def max[T: c.WeakTypeTag, U >: T: c.WeakTypeTag](c: BlackboxContext)(ord: c.Expr[Ordering[U]], ctx: c.Expr[Scheduler]): c.Expr[T] = {
+        import c.universe._
+
+        val (ordv, ordg) = c.nonFunctionToLocal[Ordering[U]](ord)
+        val op = reify { (x: T, y: T) => if (ordg.splice.compare(x, y) > 0) x else y }
+        reify {
+          ordv.splice
+          reduce[T, T](c)(op)(ctx).splice
+        }
+      }
+
+      def findIndex[T: c.WeakTypeTag, U >: T: c.WeakTypeTag](c: BlackboxContext)(calleeExpr: c.Expr[Arrays.Ops[T]])(p: c.Expr[U => Boolean])(ctx: c.Expr[Scheduler]): c.Expr[Option[Int]] = {
+        import c.universe._
+
+        val (lv, pred) = c.nonFunctionToLocal[U => Boolean](p)
+
+        val result = reify {
+          import scala._
+          import collection.par
+          import par._
+          import workstealing._
+          import internal._
+          import scala.collection.par
+          lv.splice
+          val callee = calleeExpr.splice
+          val stealer = callee.stealer
+          val kernel = new scala.collection.par.workstealing.Arrays.ArrayKernel[T, Option[Int]] {
+            def zero = None
+            def combine(a: Option[Int], b: Option[Int]) = if (a.isDefined) a else b
+            def apply(node: Node[T, Option[Int]], from: Int, to: Int) = {
+              var i = from
+
+              val arr = callee.array.seq
+              while (i < to && !pred.splice(arr(i))) {
+                i += 1
+              }
+              if (i < to) {
+                setTerminationCause(ResultFound)
+                Some(i)
+              }
+              else None
+            }
+          }
+          val result = ctx.splice.invokeParallelOperation(stealer, kernel)
+          result
+        }
+        c.inlineAndReset(result)
+      }
+
+      def find[T: c.WeakTypeTag, U >: T: c.WeakTypeTag](c: BlackboxContext)(p: c.Expr[U => Boolean])(ctx: c.Expr[Scheduler]): c.Expr[Option[T]] = {
+        import c.universe._
+
+        val (calleeExpressionv, calleeExpressiong) = c.nonFunctionToLocal(c.Expr[Arrays.Ops[T]](c.applyPrefix))
+        val found = findIndex[T, T](c)(calleeExpressiong)(p)(ctx)
+        reify {
+          calleeExpressionv.splice
+          val mayBeIndex = found.splice
+          val result =
+            if (mayBeIndex.isDefined) Some(calleeExpressiong.splice.array.seq(mayBeIndex.get))
+            else None
+          result
+        }
+      }
+
+      def forall[T: c.WeakTypeTag, U >: T: c.WeakTypeTag](c: BlackboxContext)(p: c.Expr[U => Boolean])(ctx: c.Expr[Scheduler]): c.Expr[Boolean] = {
+        import c.universe._
+
+        val (calleeExpressionv, calleeExpressiong) = c.nonFunctionToLocal(c.Expr[Arrays.Ops[T]](c.applyPrefix))
+        val np = reify {
+          (x: T) => !p.splice(x)
+        }
+        val found = findIndex[T, T](c)(calleeExpressiong)(np)(ctx)
+        reify {
+          calleeExpressionv.splice
+          found.splice.isEmpty
+        }
+      }
+
+      def exists[T: c.WeakTypeTag, U >: T: c.WeakTypeTag](c: BlackboxContext)(p: c.Expr[U => Boolean])(ctx: c.Expr[Scheduler]): c.Expr[Boolean] = {
+        import c.universe._
+
+        val (calleeExpressionv, calleeExpressiong) = c.nonFunctionToLocal(c.Expr[Arrays.Ops[T]](c.applyPrefix))
+        val found = findIndex[T, U](c)(calleeExpressiong)(p)(ctx)
+        reify {
+          calleeExpressionv.splice
+          found.splice.nonEmpty
+        }
+      }
+    */
 }

--- a/src/main/scala/scala/collection/optimizer/package.scala
+++ b/src/main/scala/scala/collection/optimizer/package.scala
@@ -5,6 +5,7 @@ package scala.collection
 import scala.language.experimental.macros
 import scala.reflect.macros._
 import scala.reflect.macros.whitebox.Context
+import scala.reflect.macros.blackbox.{Context => BlackBoxContext}
 
 
 
@@ -12,6 +13,18 @@ package object optimizer {
   final val debugOutput = false
   final def debug(s: String) = if (debugOutput) println(s)
   final val echoSplicedCode = false
+
+  def zero(c: BlackBoxContext)(t:c.Type): c.Tree = {
+    import c.universe._
+    if (t <:< typeOf[Int]) q"0"
+    else if(t <:< typeOf[Byte]) q"0.toByte"
+    else if(t <:< typeOf[Long]) q"0L"
+    else if(t <:< typeOf[Short]) q"0.toShort"
+    else if (t <:< typeOf[Boolean]) q"false"
+    else if (t <:< typeOf[Double]) q"0.0d"
+    else if (t <:< typeOf[Float]) q"0.0f"
+    else q"null"
+  }
 
   def optimize[T](exp: T): Any = macro optimize_impl[T]
 

--- a/src/main/scala/scala/collection/optimizer/package.scala
+++ b/src/main/scala/scala/collection/optimizer/package.scala
@@ -6,10 +6,14 @@ import scala.language.experimental.macros
 import scala.reflect.macros._
 import scala.reflect.macros.whitebox.Context
 import scala.reflect.macros.blackbox.{Context => BlackBoxContext}
+import scala.collection.optimizer.Optimized.OptimizedOps
 
 
+package object optimizer extends Lists.Scope {
 
-package object optimizer {
+  implicit def seq2opt[Repr](seq: Repr) = new OptimizedOps(seq)
+
+
   final val debugOutput = false
   final def debug(s: String) = if (debugOutput) println(s)
   final val echoSplicedCode = false

--- a/src/main/scala/scala/collection/par/workstealing/internal/optimizer.scala
+++ b/src/main/scala/scala/collection/par/workstealing/internal/optimizer.scala
@@ -132,10 +132,13 @@ class Optimizer[C <: Context](val c: C) {
     
   }
 
-  def inlineAndReset[T](expr: c.Expr[T]): c.Expr[T] = {
+  def inlineAndReset[T](expr: c.Expr[T]): c.Expr[T] = c.Expr[T](inlineAndReset(expr.tree))
+
+
+  def inlineAndReset(expr: c.Tree): c.Tree = {
     val inliner = new Inlining.Optimization
     val global = c.universe.asInstanceOf[scala.tools.nsc.Global]
-    c.Expr[T](global.brutallyResetAttrs(inliner.transform(expr.tree).asInstanceOf[global.Tree]).asInstanceOf[c.Tree])
+    global.brutallyResetAttrs(inliner.transform(expr).asInstanceOf[global.Tree]).asInstanceOf[c.Tree]
   }
 
   /* fusion */

--- a/src/test/scala/org/scala/optimized/test/scalameter/Generators.scala
+++ b/src/test/scala/org/scala/optimized/test/scalameter/Generators.scala
@@ -16,6 +16,9 @@ trait Generators {
   def ranges(from: Int) = for (size <- sizes(from)) yield 0 until size
   def ranges(sizes: Gen[Int]) = for (size <- sizes) yield 0 until size
   def arrays(from: Int) = for (size <- sizes(from)) yield (0 until size).toArray
+
+  def lists(from: Int) = for (size <- sizes(from)) yield (0 until size).toList
+
   def arraysBoxed(from: Int) = for (size <- sizes(from)) yield {
     val r = new Array[java.lang.Integer](size)
     (0 until size).foreach { x => r(x) = x: java.lang.Integer }

--- a/src/test/scala/org/scala/optimized/test/scalameter/OptimizedBlockBench.scala
+++ b/src/test/scala/org/scala/optimized/test/scalameter/OptimizedBlockBench.scala
@@ -4,16 +4,12 @@ package scalameter
 
 import scala.collection.optimizer._
 import org.scalameter.api._
+import org.scalameter.PerformanceTest.OnlineRegressionReport
 
 
-
-class OptimizedBlockBench extends PerformanceTest.Regression with Serializable with Generators {
+class OptimizedBlockBench extends OnlineRegressionReport with Serializable with Generators {
 
   /* config */
-
-  def persistor = new SerializationPersistor
-
-
 
   val opts = Context(
     exec.minWarmupRuns -> 50,

--- a/src/test/scala/org/scala/optimized/test/scalameter/OptimizedListBench.scala
+++ b/src/test/scala/org/scala/optimized/test/scalameter/OptimizedListBench.scala
@@ -1,0 +1,127 @@
+package org.scala.optimized.test.scalameter
+
+import org.scalameter.api._
+import org.scalameter.PerformanceTest.OnlineRegressionReport
+import org.scala.optimized.test.par.scalameter.Generators
+import scala.collection.optimizer._
+
+
+class OptimizedListBench extends OnlineRegressionReport with Serializable with Generators {
+
+  /* config */
+
+  val tiny = 10000
+  val small = 100000
+  val normal = 300000
+
+  val opts = Context(
+    exec.minWarmupRuns -> 30,
+    exec.maxWarmupRuns -> 60,
+    exec.benchRuns -> 40,
+    exec.independentSamples -> 5,
+    exec.outliers.suspectPercent -> 40,
+    exec.outliers.retries -> 20,
+    exec.jvmflags -> "-server -Xms1536m -Xmx1536m -XX:MaxPermSize=256m -XX:ReservedCodeCacheSize=64m -XX:+UseCondCardMark -XX:CompileThreshold=100 -Dscala.collection.parallel.range.manual_optimizations=false",
+    reports.regression.noiseMagnitude -> 0.15)
+
+  /* tests */
+
+  performance of "Optimized[List]" config (opts) in {
+
+    measure method "reduce" in {
+      using(lists(normal)) curve ("Sequential") in {
+        x => x.reduce(_ + _)
+      }
+
+      using(lists(normal)) curve ("Optimized") in {
+        x => x.opt.reduce(_ + _)
+      }
+    }
+
+    measure method "aggregate" in {
+      using(lists(normal)) curve ("Sequential") in {
+        x => x.aggregate(0)(_ + _, _ + _)
+      }
+
+      using(lists(normal)) curve ("Optimized") in {
+        x => x.opt.aggregate(0)(_ + _)(_ + _)
+      }
+    }
+    /*
+        measure method "filter" in {
+          using(lists(normal)) curve ("Sequential") in {
+            x => x.filter(_ % 3 == 0)
+          }
+
+          using(lists(normal)) curve ("Optimized") in {
+            x => x.opt.filter(_ % 3 == 0)
+          }
+        }
+
+        measure method "find" in {
+          using(lists(normal)) curve ("Sequential") in {
+            x => x.find(x => x == -1)
+          }
+
+          using(lists(normal)) curve ("Optimized") in {
+            x => x.opt.find(x => x == -1)
+          }
+        }
+    */
+    performance of "derivative" in {
+      /*
+      measure method "count" in {
+        using(lists(normal)) curve ("Sequential") in {
+          x => x.count(x => x % 2 == 1)
+        }
+
+        using(lists(normal)) curve ("Optimized") in {
+          x => x.opt.count(x => x % 2 == 1)
+        }
+      }*/
+
+      measure method "sum" in {
+        using(lists(normal)) curve ("Sequential") in {
+          x => x.sum
+        }
+
+        using(lists(normal)) curve ("Optimized") in {
+          x => x.opt.sum
+        }
+      }
+
+      measure method "product" in {
+        using(lists(normal)) curve ("Sequential") in {
+          x => x.product
+        }
+
+        using(lists(normal)) curve ("Optimized") in {
+          x => x.opt.product
+        }
+      }
+
+      measure method "min" in {
+        using(lists(normal)) curve ("Sequential") in {
+          x => x.min
+        }
+
+        using(lists(normal)) curve ("Optimized") in {
+          x => x.opt.min
+        }
+      }
+
+      measure method "max" in {
+        using(lists(normal)) curve ("Sequential") in {
+          x => x.max
+        }
+
+        using(lists(normal)) curve ("Optimized") in {
+          x => x.opt.max
+        }
+      }
+    }
+  }
+
+
+}
+

--- a/src/test/scala/org/scala/optimized/test/scalatest/OptimizedListTest.scala
+++ b/src/test/scala/org/scala/optimized/test/scalatest/OptimizedListTest.scala
@@ -1,0 +1,23 @@
+package org.scala.optimized.test.scalatest
+
+import org.scalatest._
+import org.scalatest.concurrent.Timeouts
+import scala.collection.par._
+import scala.collection.optimizer.{Lists, Optimized}
+
+
+class OptimizedListTest extends FunSuite with Timeouts {
+
+  test("aggregate") {
+    val res0 = List(1,3,4,5,6,7)
+
+    val res1 = new Optimized(res0)
+
+
+    val res2 = new Lists.Ops(res1)
+
+    println(res2.aggregate(0)(_+_)(_+_))
+
+  }
+}
+

--- a/src/test/scala/org/scala/optimized/test/scalatest/OptimizedListTest.scala
+++ b/src/test/scala/org/scala/optimized/test/scalatest/OptimizedListTest.scala
@@ -2,22 +2,129 @@ package org.scala.optimized.test.scalatest
 
 import org.scalatest._
 import org.scalatest.concurrent.Timeouts
+import Matchers._
 import scala.collection.par._
 import scala.collection.optimizer.{Lists, Optimized}
+import org.scalatest.prop.{PropertyChecks}
+import scala.util.Try
 
 
-class OptimizedListTest extends FunSuite with Timeouts {
+class OptimizedListTest extends FunSuite with Timeouts with PropertyChecks {
 
   test("aggregate") {
-    val res0 = List(1,3,4,5,6,7)
+    forAll { (res0: List[Int]) =>
+      val res1 = new Optimized(res0)
+      val res2 = new Lists.Ops(res1)
+      res2.aggregate(0)(_ + _)(_ + _) shouldBe res0.aggregate(0)(_ + _, _ + _)
+    }
+  }
 
-    val res1 = new Optimized(res0)
+  test("reduce") {
+    forAll { (res0: List[Int]) =>
+      val res1 = new Optimized(res0)
+      val res2 = new Lists.Ops(res1)
+      whenever(res0.nonEmpty)(res2.reduce(_ + _) shouldBe res0.reduce(_ + _))
+    }
+  }
 
+  test("fold") {
+    forAll { (res0: List[Int]) =>
+      val res1 = new Optimized(res0)
+      val res2 = new Lists.Ops(res1)
+      res2.fold(0)(_ + _) shouldBe res0.fold(0)(_ + _)
+    }
+  }
 
-    val res2 = new Lists.Ops(res1)
+  test("min") {
+    forAll { (res0: List[Int]) =>
+      val res1 = new Optimized(res0)
+      val res2 = new Lists.Ops(res1)
+      whenever(res0.nonEmpty)(res2.min shouldBe res0.min)
+    }
+  }
 
-    println(res2.aggregate(0)(_+_)(_+_))
+  test("max") {
+    forAll { (res0: List[Int]) =>
+      val res1 = new Optimized(res0)
+      val res2 = new Lists.Ops(res1)
+      whenever(res0.nonEmpty)(res2.max shouldBe res0.max)
+    }
+  }
 
+  test("sum") {
+    forAll { (res0: List[Int]) =>
+      val res1 = new Optimized(res0)
+      val res2 = new Lists.Ops(res1)
+      res2.sum shouldBe res0.sum
+    }
+  }
+
+  test("product") {
+    forAll { (res0: List[Int]) =>
+      val res1 = new Optimized(res0)
+      val res2 = new Lists.Ops(res1)
+      res2.product shouldBe res0.product
+    }
+  }
+
+  test("find") {
+    forAll { (res0: List[Int], q: Int) =>
+      val res1 = new Optimized(res0)
+      val res2 = new Lists.Ops(res1)
+      res2.find(_ == q) shouldBe res0.find(_ == q)
+    }
+  }
+
+  test("exists") {
+    forAll { (res0: List[Int], q: Int) =>
+      val res1 = new Optimized(res0)
+      val res2 = new Lists.Ops(res1)
+      res2.exists(_ == q) shouldBe res0.exists(_ == q)
+    }
+  }
+
+  test("map") {
+    forAll { (res0: List[Int], q: Int => Int) =>
+      val res1 = new Optimized(res0)
+      val res2 = new Lists.Ops(res1)
+      res2.map(q) shouldBe res0.map(q)
+    }
+  }
+
+  test("flatMap") {
+    forAll { (res0: List[Int], q: Int => List[Int]) =>
+      val res1 = new Optimized(res0)
+      val res2 = new Lists.Ops(res1)
+      res2.flatMap(q) shouldBe res0.flatMap(q)
+    }
   }
 }
 
+/*
+
+trait Tree {
+  def withParent(parent: Tree): this.type
+}
+object NoParent extends Tree
+class Sel private(private[this] var _p: Tree, private[this] var _n:Tree, private val _parent:Tree = NoParent, private val orig: Sel = null) extends Tree{
+  def withParent(parent: Tree) = {
+    Sel(null, null, parent, this)
+  }
+  def parent = _parent
+  def p: Tree = {
+    if(_p eq null && (orig ne null)) _p = orig.p.withParent(this)
+    /*if(this._p == NoParent) ??? else*/ _p
+  }
+  def n: Tree = {
+    if(_n eq null &&(orig ne null)) _n = orig.p.withParent(this)
+    /*if(this._n == NoParent) ??? else*/ _n
+  }
+}
+
+object Sel{
+  def apply(p: Tree, n: Tree) = {
+    val s = new Sel(NoParent, NoParent, NoParent)
+    s._p = p.withParent(s)
+    s._n = n.withParent(s)
+  }
+}*/

--- a/src/test/scala/org/scala/optimized/test/scalatest/OptimizedListTest.scala
+++ b/src/test/scala/org/scala/optimized/test/scalatest/OptimizedListTest.scala
@@ -60,7 +60,7 @@ class OptimizedListTest extends FunSuite with Timeouts with PropertyChecks {
       res2.product shouldBe res0.product
     }
   }
-
+/*
   test("find") {
     forAll { (res0: List[Int], q: Int) =>
       val res2 = res0.opt
@@ -102,4 +102,5 @@ class OptimizedListTest extends FunSuite with Timeouts with PropertyChecks {
       res2.filter(q) shouldBe res0.filter(q)
     }
   }
+*/
 }

--- a/src/test/scala/org/scala/optimized/test/scalatest/OptimizedListTest.scala
+++ b/src/test/scala/org/scala/optimized/test/scalatest/OptimizedListTest.scala
@@ -4,7 +4,7 @@ import org.scalatest._
 import org.scalatest.concurrent.Timeouts
 import Matchers._
 import scala.collection.par._
-import scala.collection.optimizer.{Lists, Optimized}
+import scala.collection.optimizer._
 import org.scalatest.prop.{PropertyChecks}
 import scala.util.Try
 
@@ -13,118 +13,93 @@ class OptimizedListTest extends FunSuite with Timeouts with PropertyChecks {
 
   test("aggregate") {
     forAll { (res0: List[Int]) =>
-      val res1 = new Optimized(res0)
-      val res2 = new Lists.Ops(res1)
+      val res2 = res0.opt
       res2.aggregate(0)(_ + _)(_ + _) shouldBe res0.aggregate(0)(_ + _, _ + _)
     }
   }
 
   test("reduce") {
     forAll { (res0: List[Int]) =>
-      val res1 = new Optimized(res0)
-      val res2 = new Lists.Ops(res1)
+      val res2 = res0.opt
       whenever(res0.nonEmpty)(res2.reduce(_ + _) shouldBe res0.reduce(_ + _))
     }
   }
 
+
   test("fold") {
     forAll { (res0: List[Int]) =>
-      val res1 = new Optimized(res0)
-      val res2 = new Lists.Ops(res1)
+      val res2 = res0.opt
       res2.fold(0)(_ + _) shouldBe res0.fold(0)(_ + _)
     }
   }
 
   test("min") {
     forAll { (res0: List[Int]) =>
-      val res1 = new Optimized(res0)
-      val res2 = new Lists.Ops(res1)
+      val res2 = res0.opt
       whenever(res0.nonEmpty)(res2.min shouldBe res0.min)
     }
   }
 
   test("max") {
     forAll { (res0: List[Int]) =>
-      val res1 = new Optimized(res0)
-      val res2 = new Lists.Ops(res1)
+      val res2 = res0.opt
       whenever(res0.nonEmpty)(res2.max shouldBe res0.max)
     }
   }
 
   test("sum") {
     forAll { (res0: List[Int]) =>
-      val res1 = new Optimized(res0)
-      val res2 = new Lists.Ops(res1)
+      val res2 = res0.opt
       res2.sum shouldBe res0.sum
     }
   }
 
   test("product") {
     forAll { (res0: List[Int]) =>
-      val res1 = new Optimized(res0)
-      val res2 = new Lists.Ops(res1)
+      val res2 = res0.opt
       res2.product shouldBe res0.product
     }
   }
 
   test("find") {
     forAll { (res0: List[Int], q: Int) =>
-      val res1 = new Optimized(res0)
-      val res2 = new Lists.Ops(res1)
+      val res2 = res0.opt
       res2.find(_ == q) shouldBe res0.find(_ == q)
     }
   }
 
   test("exists") {
     forAll { (res0: List[Int], q: Int) =>
-      val res1 = new Optimized(res0)
-      val res2 = new Lists.Ops(res1)
+      val res2 = res0.opt
       res2.exists(_ == q) shouldBe res0.exists(_ == q)
     }
   }
 
   test("map") {
     forAll { (res0: List[Int], q: Int => Int) =>
-      val res1 = new Optimized(res0)
-      val res2 = new Lists.Ops(res1)
+      val res2 = res0.opt
       res2.map(q) shouldBe res0.map(q)
     }
   }
 
   test("flatMap") {
     forAll { (res0: List[Int], q: Int => List[Int]) =>
-      val res1 = new Optimized(res0)
-      val res2 = new Lists.Ops(res1)
+      val res2 = res0.opt
       res2.flatMap(q) shouldBe res0.flatMap(q)
     }
   }
-}
 
-/*
+  test("count") {
+    forAll { (res0: List[Int], q: Int => Boolean) =>
+      val res2 = res0.opt
+      res2.count(q) shouldBe res0.count(q)
+    }
+  }
 
-trait Tree {
-  def withParent(parent: Tree): this.type
-}
-object NoParent extends Tree
-class Sel private(private[this] var _p: Tree, private[this] var _n:Tree, private val _parent:Tree = NoParent, private val orig: Sel = null) extends Tree{
-  def withParent(parent: Tree) = {
-    Sel(null, null, parent, this)
-  }
-  def parent = _parent
-  def p: Tree = {
-    if(_p eq null && (orig ne null)) _p = orig.p.withParent(this)
-    /*if(this._p == NoParent) ??? else*/ _p
-  }
-  def n: Tree = {
-    if(_n eq null &&(orig ne null)) _n = orig.p.withParent(this)
-    /*if(this._n == NoParent) ??? else*/ _n
+  test("filter") {
+    forAll { (res0: List[Int], q: Int => Boolean) =>
+      val res2 = res0.opt
+      res2.filter(q) shouldBe res0.filter(q)
+    }
   }
 }
-
-object Sel{
-  def apply(p: Tree, n: Tree) = {
-    val s = new Sel(NoParent, NoParent, NoParent)
-    s._p = p.withParent(s)
-    s._n = n.withParent(s)
-  }
-}*/


### PR DESCRIPTION
Only operations that make sense for now: 
eg there's no reason to implement List.count using macros before lists are specialized as in both cases performance is dominated by unboxing element for predicate.
