### PR TITLE
Changes in ScalaBlitz for the Scala BlitzViews project

### DIFF
--- a/src/main/scala/scala/collection/par/workstealing/Reducables.scala
+++ b/src/main/scala/scala/collection/par/workstealing/Reducables.scala
@@ -35,6 +35,14 @@ object Reducables {
     def seq: Repr
     def reduce[U >: T](op: (U, U) => U)(implicit ctx: Scheduler): U = macro internal.ReducablesMacros.reduce[T, U, Repr]
     def mapReduce[R](mapper: T => R)(reducer: (R, R) => R)(implicit ctx: Scheduler): R = macro internal.ReducablesMacros.mapReduce[T, T, R, Repr]
+    /**
+      * seqop is given a cell containing next element to process and current result, 
+      * examples of operations performed by seqop could be: 
+      * combine current result with the provided element;
+      * discard  new element and return current result;
+      * discard current result and return new element.
+      */
+    def mapFilterReduce[R](seqop: (T, ResultCell[R]) => ResultCell[R], stopPredicate: (T, ResultCell[R]) => Boolean)(reducer: (R, R) => R)(implicit ctx: Scheduler): ResultCell[R] = macro internal.ReducablesMacros.mapFilterReduce[T, T, R, Repr]
     def fold[U >: T](z: => U)(op: (U, U) => U)(implicit ctx: Scheduler): U = macro internal.ReducablesMacros.fold[T, U, Repr]
     def aggregate[S](z: S)(combop: (S, S) => S)(seqop: (S, T) => S)(implicit ctx: Scheduler): S = macro internal.ReducablesMacros.aggregate[T, S, Repr]
     def foreach[U >: T](action: U => Unit)(implicit ctx: Scheduler): Unit = macro internal.ReducablesMacros.foreach[T, U, Repr]

--- a/src/main/scala/scala/collection/par/workstealing/internal/reducables.scala
+++ b/src/main/scala/scala/collection/par/workstealing/internal/reducables.scala
@@ -284,8 +284,7 @@ object ReducablesMacros {
     (c: BlackboxContext)
     (seqop: c.Expr[(U, ResultCell[R]) => ResultCell[R]], stopPredicate: c.Expr[(U, ResultCell[R]) => Boolean])
     (reducer: c.Expr[(R, R) => R])(ctx: c.Expr[Scheduler])
-    : c.Expr[ResultCell[R]] =
-  {
+    : c.Expr[ResultCell[R]] = {
     import c.universe._
 
     val (lv, op) = c.nonFunctionToLocal[(R, R) => R](reducer)

--- a/src/main/scala/scala/collection/par/workstealing/package.scala
+++ b/src/main/scala/scala/collection/par/workstealing/package.scala
@@ -55,10 +55,11 @@ package workstealing {
     }
     def isEmpty = empty
     override def toString = if (empty) "ResultCell(empty)" else "ResultCell(" + r + ")"
+    def toOption: Option[T] = if (empty) None else Some(r)
   }
 
   object ResultFound extends Scheduler.TerminationCause {
-    def validateResult[R](r: R) = if (r.isInstanceOf[Option[_]]) r else ???
+    def validateResult[R](r: R) = r // XXX: useless now?
   }
 
   final case class ProgressStatus(val start: Int, var progress: Int)


### PR DESCRIPTION
Hi guys, these changes were made during my semester project "BlitzViews" and are necessary for the next step: separating BlitzViews from the ScalaBlitz repository and using the latter as a dependency. The first change was made by Dmitry, the second is a small helper and the third was reviewed by Dmitry. Feel free to comment. Note: should I separate in 3 commits?
- Introduces a new Reducable operation: mapFilterReduce
- Add toOption for ResultCell
- Fix validateResult (remove legacy check)
